### PR TITLE
t/70: Updated link after focusTracker moved from editor to editor.ui.

### DIFF
--- a/src/link.js
+++ b/src/link.js
@@ -136,7 +136,7 @@ export default class Link extends Feature {
 
 		// Add balloonPanel.view#element to FocusTracker.
 		// @TODO: Do it automatically ckeditor5-core#23
-		editor.focusTracker.add( balloonPanelView.element );
+		editor.ui.focusTracker.add( balloonPanelView.element );
 
 		// Handle click on view document and show panel when selection is placed inside the link element.
 		// Keep panel open until selection will be inside the same link element.
@@ -176,7 +176,7 @@ export default class Link extends Feature {
 			callback: () => this._hidePanel()
 		} );
 
-		editor.ui.body.add( balloonPanelView );
+		editor.ui.view.body.add( balloonPanelView );
 
 		return balloonPanelView;
 	}

--- a/tests/link.js
+++ b/tests/link.js
@@ -170,11 +170,11 @@ describe( 'Link', () => {
 		} );
 
 		it( 'should add balloon panel element to focus tracker', () => {
-			editor.focusTracker.isFocused = false;
+			editor.ui.focusTracker.isFocused = false;
 
 			balloonPanelView.element.dispatchEvent( new Event( 'focus' ) );
 
-			expect( editor.focusTracker.isFocused ).to.true;
+			expect( editor.ui.focusTracker.isFocused ).to.true;
 		} );
 
 		describe( 'close listeners', () => {


### PR DESCRIPTION
Requires https://github.com/ckeditor/ckeditor5-editor-classic/pull/39.

Closes #70.