### PR TITLE
t/81: Removed obsolete View.addChildren() calls from LinkFormView.

### DIFF
--- a/src/ui/linkformview.js
+++ b/src/ui/linkformview.js
@@ -61,9 +61,6 @@ export default class LinkFormView extends View {
 		 */
 		this.unlinkButtonView = this._createButton( t( 'Unlink' ), 'unlink' );
 
-		// Register child views.
-		this.addChildren( [ this.urlInputView, this.saveButtonView, this.cancelButtonView, this.unlinkButtonView ] );
-
 		Template.extend( this.saveButtonView.template, {
 			attributes: {
 				class: [

--- a/tests/ui/linkformview.js
+++ b/tests/ui/linkformview.js
@@ -12,7 +12,7 @@ describe( 'LinkFormView', () => {
 	beforeEach( () => {
 		view = new LinkFormView( { t: () => {} } );
 
-		view.init();
+		return view.init();
 	} );
 
 	describe( 'constructor()', () => {


### PR DESCRIPTION
Requires https://github.com/ckeditor/ckeditor5-ui/pull/147.
Closes #81.

