### PR TITLE
Made showPanel() and hidePanel() protected

### DIFF
--- a/src/link.js
+++ b/src/link.js
@@ -90,21 +90,21 @@ export default class Link extends Plugin {
 		// Execute link command after clicking on formView `Save` button.
 		this.listenTo( formView, 'submit', () => {
 			editor.execute( 'link', formView.urlInputView.inputView.element.value );
-			this.hidePanel( true );
+			this._hidePanel( true );
 		} );
 
 		// Execute unlink command after clicking on formView `Unlink` button.
 		this.listenTo( formView, 'unlink', () => {
 			editor.execute( 'unlink' );
-			this.hidePanel( true );
+			this._hidePanel( true );
 		} );
 
 		// Hide the panel after clicking on formView `Cancel` button.
-		this.listenTo( formView, 'cancel', () => this.hidePanel( true ) );
+		this.listenTo( formView, 'cancel', () => this._hidePanel( true ) );
 
 		// Close the panel on esc key press when the form has focus.
 		formView.keystrokes.set( 'Esc', ( data, cancel ) => {
-			this.hidePanel( true );
+			this._hidePanel( true );
 			cancel();
 		} );
 
@@ -123,7 +123,7 @@ export default class Link extends Plugin {
 		const t = editor.t;
 
 		// Handle `Ctrl+K` keystroke and show the panel.
-		editor.keystrokes.set( 'CTRL+K', () => this.showPanel( true ) );
+		editor.keystrokes.set( 'CTRL+K', () => this._showPanel( true ) );
 
 		editor.ui.componentFactory.add( 'link', ( locale ) => {
 			const button = new ButtonView( locale );
@@ -138,7 +138,7 @@ export default class Link extends Plugin {
 			button.bind( 'isEnabled' ).to( linkCommand, 'isEnabled' );
 
 			// Show the panel on button click.
-			this.listenTo( button, 'execute', () => this.showPanel( true ) );
+			this.listenTo( button, 'execute', () => this._showPanel( true ) );
 
 			return button;
 		} );
@@ -191,7 +191,7 @@ export default class Link extends Plugin {
 			// When collapsed selection is inside link element (link element is clicked).
 			if ( viewSelection.isCollapsed && parentLink ) {
 				// Then show panel but keep focus inside editor editable.
-				this.showPanel();
+				this._showPanel();
 
 				// Avoid duplication of the same listener.
 				this.stopListening( viewDocument, 'render' );
@@ -202,7 +202,7 @@ export default class Link extends Plugin {
 					const currentParentLink = getPositionParentLink( viewSelection.getFirstPosition() );
 
 					if ( !viewSelection.isCollapsed || parentLink !== currentParentLink ) {
-						this.hidePanel();
+						this._hidePanel();
 					} else {
 						this._balloon.updatePosition();
 					}
@@ -221,7 +221,7 @@ export default class Link extends Plugin {
 		// Close the panel on the Esc key press when the editable has focus and the balloon is visible.
 		this.editor.keystrokes.set( 'Esc', ( data, cancel ) => {
 			if ( this._balloon.visibleView === this.formView ) {
-				this.hidePanel();
+				this._hidePanel();
 				cancel();
 			}
 		} );
@@ -231,7 +231,7 @@ export default class Link extends Plugin {
 			emitter: this.formView,
 			activator: () => this._balloon.hasView( this.formView ),
 			contextElement: this._balloon.view.element,
-			callback: () => this.hidePanel()
+			callback: () => this._hidePanel()
 		} );
 	}
 
@@ -239,10 +239,11 @@ export default class Link extends Plugin {
 	 * Adds the {@link #formView} to the {@link #_balloon}.
 	 * When view is already added then try to focus it `focusInput` parameter is set as true.
 	 *
+	 * @protected
 	 * @param {Boolean} [focusInput=false] When `true`, link form will be focused on panel show.
 	 * @return {Promise} A promise resolved when the {#formView} {@link module:ui/view~View#init} is done.
 	 */
-	showPanel( focusInput ) {
+	_showPanel( focusInput ) {
 		if ( this._balloon.hasView( this.formView ) ) {
 			// Check if formView should be focused and focus it if is visible.
 			if ( focusInput && this._balloon.visibleView === this.formView ) {
@@ -253,21 +254,22 @@ export default class Link extends Plugin {
 		}
 
 		return this._balloon.add( {
-			view: this.formView,
-			position: this._getBalloonPositionData()
-		} ).then( () => {
-			if ( focusInput ) {
-				this.formView.urlInputView.select();
-			}
-		} );
+				view: this.formView,
+				position: this._getBalloonPositionData()
+			} ).then( () => {
+				if ( focusInput ) {
+					this.formView.urlInputView.select();
+				}
+			} );
 	}
 
 	/**
 	 * Removes the {@link #formView} from the {@link #_balloon}.
 	 *
+	 * @protected
 	 * @param {Boolean} [focusEditable=false] When `true`, editable focus will be restored on panel hide.
 	 */
-	hidePanel( focusEditable ) {
+	_hidePanel( focusEditable ) {
 		if ( !this._balloon.hasView( this.formView ) ) {
 			return;
 		}

--- a/src/link.js
+++ b/src/link.js
@@ -241,7 +241,7 @@ export default class Link extends Plugin {
 	 *
 	 * @protected
 	 * @param {Boolean} [focusInput=false] When `true`, link form will be focused on panel show.
-	 * @return {Promise} A promise resolved when the {#formView} {@link module:ui/view~View#init} is done.
+	 * @return {Promise} A promise resolved when the {@link #formView} {@link module:ui/view~View#init} is done.
 	 */
 	_showPanel( focusInput ) {
 		if ( this._balloon.hasView( this.formView ) ) {
@@ -265,6 +265,8 @@ export default class Link extends Plugin {
 
 	/**
 	 * Removes the {@link #formView} from the {@link #_balloon}.
+	 *
+	 * See {@link #_showPanel}.
 	 *
 	 * @protected
 	 * @param {Boolean} [focusEditable=false] When `true`, editable focus will be restored on panel hide.

--- a/src/link.js
+++ b/src/link.js
@@ -240,20 +240,21 @@ export default class Link extends Plugin {
 	 *
 	 * @private
 	 * @param {Boolean} [focusInput=false] When `true`, link form will be focused on panel show.
+	 * @return {Promise} A promise resolved when the {#formView} {@link module:ui/view~View#init} is done.
 	 */
 	_showPanel( focusInput ) {
 		if ( this._balloon.hasView( this.formView ) ) {
-			return;
+			return Promise.resolve();
 		}
 
-		this._balloon.add( {
+		return this._balloon.add( {
 			view: this.formView,
 			position: this._getBalloonPositionData()
+		} ).then( () => {
+			if ( focusInput ) {
+				this.formView.urlInputView.select();
+			}
 		} );
-
-		if ( focusInput ) {
-			this.formView.urlInputView.select();
-		}
 	}
 
 	/**

--- a/tests/link.js
+++ b/tests/link.js
@@ -70,7 +70,7 @@ describe( 'Link', () => {
 		expect( editor.editing.view.getObserver( ClickObserver ) ).to.instanceOf( ClickObserver );
 	} );
 
-	describe( 'showPanel()', () => {
+	describe( '_showPanel()', () => {
 		let balloonAddSpy;
 
 		beforeEach( () => {
@@ -79,7 +79,7 @@ describe( 'Link', () => {
 		} );
 
 		it( 'should return promise', () => {
-			const returned = linkFeature.showPanel();
+			const returned = linkFeature._showPanel();
 
 			expect( returned ).to.instanceof( Promise );
 
@@ -90,7 +90,7 @@ describe( 'Link', () => {
 			setModelData( editor.document, '<paragraph>f[o]o</paragraph>' );
 			const selectedRange = editorElement.ownerDocument.getSelection().getRangeAt( 0 );
 
-			return linkFeature.showPanel()
+			return linkFeature._showPanel()
 				.then( () => {
 					expect( balloon.visibleView ).to.equal( formView );
 
@@ -108,7 +108,7 @@ describe( 'Link', () => {
 			setModelData( editor.document, '<paragraph>f[]oo</paragraph>' );
 			const selectedRange = editorElement.ownerDocument.getSelection().getRangeAt( 0 );
 
-			return linkFeature.showPanel()
+			return linkFeature._showPanel()
 				.then( () => {
 					expect( balloon.visibleView ).to.equal( formView );
 
@@ -128,7 +128,7 @@ describe( 'Link', () => {
 			setModelData( editor.document, '<paragraph><$text linkHref="url">f[]oo</$text></paragraph>' );
 			const linkElement = editorElement.querySelector( 'a' );
 
-			return linkFeature.showPanel()
+			return linkFeature._showPanel()
 				.then( () => {
 					expect( balloon.visibleView ).to.equal( formView );
 
@@ -145,7 +145,7 @@ describe( 'Link', () => {
 		it( 'should not focus the #formView at default', () => {
 			const spy = testUtils.sinon.spy( formView.urlInputView, 'select' );
 
-			return linkFeature.showPanel()
+			return linkFeature._showPanel()
 				.then( () => {
 					sinon.assert.notCalled( spy );
 				} );
@@ -154,7 +154,7 @@ describe( 'Link', () => {
 		it( 'should not focus the #formView when called with a `false` parameter', () => {
 			const spy = testUtils.sinon.spy( formView.urlInputView, 'select' );
 
-			return linkFeature.showPanel( false )
+			return linkFeature._showPanel( false )
 				.then( () => {
 					sinon.assert.notCalled( spy );
 				} );
@@ -168,9 +168,9 @@ describe( 'Link', () => {
 				destroy: () => {}
 			};
 
-			return linkFeature.showPanel( false )
+			return linkFeature._showPanel( false )
 				.then( () => balloon.add( { view: viewMock } ) )
-				.then( () => linkFeature.showPanel( true ) )
+				.then( () => linkFeature._showPanel( true ) )
 				.then( () => {
 					sinon.assert.notCalled( spy );
 				} );
@@ -179,7 +179,7 @@ describe( 'Link', () => {
 		it( 'should focus the #formView when called with a `true` parameter', () => {
 			const spy = testUtils.sinon.spy( formView.urlInputView, 'select' );
 
-			return linkFeature.showPanel( true )
+			return linkFeature._showPanel( true )
 				.then( () => {
 					sinon.assert.calledOnce( spy );
 				} );
@@ -188,8 +188,8 @@ describe( 'Link', () => {
 		it( 'should focus the #formView when called with a `true` parameter while the balloon is open and the #formView is visible', () => {
 			const spy = testUtils.sinon.spy( formView.urlInputView, 'select' );
 
-			return linkFeature.showPanel( false )
-				.then( () => linkFeature.showPanel( true ) )
+			return linkFeature._showPanel( false )
+				.then( () => linkFeature._showPanel( true ) )
 				.then( () => {
 					sinon.assert.calledOnce( spy );
 				} );
@@ -199,7 +199,7 @@ describe( 'Link', () => {
 			editor.ui.focusTracker.isFocused = false;
 
 			// Open the #_balloon with the link inside.
-			return linkFeature.showPanel( true )
+			return linkFeature._showPanel( true )
 				.then( () => {
 					// Check if editor ui is focused.
 					expect( editor.ui.focusTracker.isFocused ).to.true;
@@ -207,42 +207,42 @@ describe( 'Link', () => {
 		} );
 	} );
 
-	describe( 'hidePanel()', () => {
+	describe( '_hidePanel()', () => {
 		beforeEach( () => {
 			return balloon.add( { view: formView } );
 		} );
 
 		it( 'should remove #formView from the #_balloon', () => {
-			linkFeature.hidePanel();
+			linkFeature._hidePanel();
 			expect( balloon.hasView( formView ) ).to.false;
 		} );
 
 		it( 'should not focus the `editable` by default', () => {
 			const spy = testUtils.sinon.spy( editor.editing.view, 'focus' );
 
-			linkFeature.hidePanel();
+			linkFeature._hidePanel();
 			sinon.assert.notCalled( spy );
 		} );
 
 		it( 'should not focus the `editable` when called with a `false` parameter', () => {
 			const spy = testUtils.sinon.spy( editor.editing.view, 'focus' );
 
-			linkFeature.hidePanel( false );
+			linkFeature._hidePanel( false );
 			sinon.assert.notCalled( spy );
 		} );
 
 		it( 'should focus the `editable` when called with a `true` parameter', () => {
 			const spy = testUtils.sinon.spy( editor.editing.view, 'focus' );
 
-			linkFeature.hidePanel( true );
+			linkFeature._hidePanel( true );
 			sinon.assert.calledOnce( spy );
 		} );
 
 		it( 'should not throw an error when #formView is not added to the `balloon`', () => {
-			linkFeature.hidePanel( true );
+			linkFeature._hidePanel( true );
 
 			expect( () => {
-				linkFeature.hidePanel( true );
+				linkFeature._hidePanel( true );
 			} ).to.not.throw();
 		} );
 
@@ -251,7 +251,7 @@ describe( 'Link', () => {
 
 			linkFeature.listenTo( editor.editing.view, 'render', spy );
 
-			linkFeature.hidePanel();
+			linkFeature._hidePanel();
 
 			editor.editing.view.render();
 
@@ -276,7 +276,7 @@ describe( 'Link', () => {
 
 		it( 'should show the #_balloon on execute event with the selected #formView', () => {
 			// Method is stubbed because it returns internal promise which can't be returned in test.
-			const spy = testUtils.sinon.stub( linkFeature, 'showPanel', () => {} );
+			const spy = testUtils.sinon.stub( linkFeature, '_showPanel', () => {} );
 
 			linkButton.fire( 'execute' );
 
@@ -312,7 +312,7 @@ describe( 'Link', () => {
 	describe( 'keyboard support', () => {
 		it( 'should show the #_balloon with selected #formView on `CTRL+K` keystroke', () => {
 			// Method is stubbed because it returns internal promise which can't be returned in test.
-			const spy = testUtils.sinon.stub( linkFeature, 'showPanel', () => {} );
+			const spy = testUtils.sinon.stub( linkFeature, '_showPanel', () => {} );
 
 			editor.keystrokes.press( { keyCode: keyCodes.k, ctrlKey: true } );
 
@@ -337,7 +337,7 @@ describe( 'Link', () => {
 			sinon.assert.notCalled( spy );
 
 			// Balloon is visible, form focused.
-			return linkFeature.showPanel( true )
+			return linkFeature._showPanel( true )
 				.then( () => {
 					formView.focusTracker.isFocused = true;
 
@@ -357,7 +357,7 @@ describe( 'Link', () => {
 		} );
 
 		it( 'should hide the #_balloon after Esc key press (from editor) and not focus the editable', () => {
-			const spy = testUtils.sinon.spy( linkFeature, 'hidePanel' );
+			const spy = testUtils.sinon.spy( linkFeature, '_hidePanel' );
 			const keyEvtData = {
 				keyCode: keyCodes.esc,
 				preventDefault: sinon.spy(),
@@ -365,7 +365,7 @@ describe( 'Link', () => {
 			};
 
 			// Balloon is visible.
-			return linkFeature.showPanel( false ).then( () => {
+			return linkFeature._showPanel( false ).then( () => {
 				editor.keystrokes.press( keyEvtData );
 
 				sinon.assert.calledWithExactly( spy );
@@ -373,7 +373,7 @@ describe( 'Link', () => {
 		} );
 
 		it( 'should not hide #_balloon after Esc key press (from editor) when #_balloon is open but is not visible', () => {
-			const spy = testUtils.sinon.spy( linkFeature, 'hidePanel' );
+			const spy = testUtils.sinon.spy( linkFeature, '_hidePanel' );
 			const keyEvtData = {
 				keyCode: keyCodes.esc,
 				preventDefault: () => {},
@@ -386,7 +386,7 @@ describe( 'Link', () => {
 				destroy: () => {}
 			};
 
-			return linkFeature.showPanel( false )
+			return linkFeature._showPanel( false )
 				.then( () => balloon.add( { view: viewMock } ) )
 				.then( () => {
 					editor.keystrokes.press( keyEvtData );
@@ -396,14 +396,14 @@ describe( 'Link', () => {
 		} );
 
 		it( 'should hide the #_balloon after Esc key press (from the form) and focus the editable', () => {
-			const spy = testUtils.sinon.spy( linkFeature, 'hidePanel' );
+			const spy = testUtils.sinon.spy( linkFeature, '_hidePanel' );
 			const keyEvtData = {
 				keyCode: keyCodes.esc,
 				preventDefault: sinon.spy(),
 				stopPropagation: sinon.spy()
 			};
 
-			return linkFeature.showPanel( true )
+			return linkFeature._showPanel( true )
 				.then( () => {
 					formView.keystrokes.press( keyEvtData );
 
@@ -414,9 +414,9 @@ describe( 'Link', () => {
 
 	describe( 'mouse support', () => {
 		it( 'should hide #_balloon and not focus editable on click outside the #_balloon', () => {
-			const spy = testUtils.sinon.spy( linkFeature, 'hidePanel' );
+			const spy = testUtils.sinon.spy( linkFeature, '_hidePanel' );
 
-			return linkFeature.showPanel( true )
+			return linkFeature._showPanel( true )
 				.then( () => {
 					document.body.dispatchEvent( new Event( 'mouseup', { bubbles: true } ) );
 
@@ -425,9 +425,9 @@ describe( 'Link', () => {
 		} );
 
 		it( 'should not hide #_balloon on click inside the #_balloon', () => {
-			const spy = testUtils.sinon.spy( linkFeature, 'hidePanel' );
+			const spy = testUtils.sinon.spy( linkFeature, '_hidePanel' );
 
-			return linkFeature.showPanel( true )
+			return linkFeature._showPanel( true )
 				.then( () => {
 					balloon.view.element.dispatchEvent( new Event( 'mouseup', { bubbles: true } ) );
 
@@ -444,7 +444,7 @@ describe( 'Link', () => {
 
 			it( 'should open with not selected formView when collapsed selection is inside link element', () => {
 				// Method is stubbed because it returns internal promise which can't be returned in test.
-				const spy = testUtils.sinon.stub( linkFeature, 'showPanel', () => {} );
+				const spy = testUtils.sinon.stub( linkFeature, '_showPanel', () => {} );
 
 				editor.document.schema.allow( { name: '$text', inside: '$root' } );
 				setModelData( editor.document, '<$text linkHref="url">fo[]o</$text>' );
@@ -456,8 +456,8 @@ describe( 'Link', () => {
 
 			it( 'should keep open and update position until collapsed selection stay inside the same link element', () => {
 				// Method is stubbed because it returns internal promise which can't be returned in test.
-				const showSpy = testUtils.sinon.stub( linkFeature, 'showPanel', () => {} );
-				const hideSpy = testUtils.sinon.stub( linkFeature, 'hidePanel' );
+				const showSpy = testUtils.sinon.stub( linkFeature, '_showPanel', () => {} );
+				const hideSpy = testUtils.sinon.stub( linkFeature, '_hidePanel' );
 				const updatePositionSpy = testUtils.sinon.stub( balloon, 'updatePosition', () => {} );
 
 				editor.document.schema.allow( { name: '$text', inside: '$root' } );
@@ -485,7 +485,7 @@ describe( 'Link', () => {
 				const updatePositionSpy = testUtils.sinon.stub( balloon, 'updatePosition', () => {} );
 
 				// Method is stubbed because it returns internal promise which can't be returned in test.
-				testUtils.sinon.stub( linkFeature, 'showPanel', () => {} );
+				testUtils.sinon.stub( linkFeature, '_showPanel', () => {} );
 
 				editor.document.schema.allow( { name: '$text', inside: '$root' } );
 				setModelData( editor.document, '<$text linkHref="url">b[]ar</$text>' );
@@ -509,10 +509,10 @@ describe( 'Link', () => {
 			} );
 
 			it( 'should close when selection goes outside the link element', () => {
-				const hideSpy = testUtils.sinon.stub( linkFeature, 'hidePanel' );
+				const hideSpy = testUtils.sinon.stub( linkFeature, '_hidePanel' );
 
 				// Method is stubbed because it returns internal promise which can't be returned in test.
-				testUtils.sinon.stub( linkFeature, 'showPanel', () => {} );
+				testUtils.sinon.stub( linkFeature, '_showPanel', () => {} );
 
 				editor.document.schema.allow( { name: '$text', inside: '$root' } );
 				setModelData( editor.document, 'foo <$text linkHref="url">b[]ar</$text>' );
@@ -531,10 +531,10 @@ describe( 'Link', () => {
 			} );
 
 			it( 'should close when selection goes to the other link element with the same href', () => {
-				const hideSpy = testUtils.sinon.stub( linkFeature, 'hidePanel' );
+				const hideSpy = testUtils.sinon.stub( linkFeature, '_hidePanel' );
 
 				// Method is stubbed because it returns internal promise which can't be returned in test.
-				testUtils.sinon.stub( linkFeature, 'showPanel', () => {} );
+				testUtils.sinon.stub( linkFeature, '_showPanel', () => {} );
 
 				editor.document.schema.allow( { name: '$text', inside: '$root' } );
 				setModelData( editor.document, '<$text linkHref="url">f[]oo</$text> bar <$text linkHref="url">biz</$text>' );
@@ -553,10 +553,10 @@ describe( 'Link', () => {
 			} );
 
 			it( 'should close when selection becomes non-collapsed', () => {
-				const hideSpy = testUtils.sinon.stub( linkFeature, 'hidePanel' );
+				const hideSpy = testUtils.sinon.stub( linkFeature, '_hidePanel' );
 
 				// Method is stubbed because it returns internal promise which can't be returned in test.
-				testUtils.sinon.stub( linkFeature, 'showPanel', () => {} );
+				testUtils.sinon.stub( linkFeature, '_showPanel', () => {} );
 
 				editor.document.schema.allow( { name: '$text', inside: '$root' } );
 				setModelData( editor.document, '<$text linkHref="url">f[]oo</$text>' );
@@ -573,7 +573,7 @@ describe( 'Link', () => {
 			} );
 
 			it( 'should not open when selection is not inside link element', () => {
-				const showSpy = testUtils.sinon.stub( linkFeature, 'showPanel' );
+				const showSpy = testUtils.sinon.stub( linkFeature, '_showPanel' );
 
 				setModelData( editor.document, '[]' );
 
@@ -583,7 +583,7 @@ describe( 'Link', () => {
 			} );
 
 			it( 'should not open when selection is non-collapsed', () => {
-				const showSpy = testUtils.sinon.stub( linkFeature, 'showPanel' );
+				const showSpy = testUtils.sinon.stub( linkFeature, '_showPanel' );
 
 				editor.document.schema.allow( { name: '$text', inside: '$root' } );
 				setModelData( editor.document, '<$text linkHref="url">f[o]o</$text>' );
@@ -626,7 +626,7 @@ describe( 'Link', () => {
 			} );
 
 			it( 'should hide and focus editable on formView#submit event', () => {
-				return linkFeature.showPanel()
+				return linkFeature._showPanel()
 					.then( () => {
 						formView.fire( 'submit' );
 
@@ -645,7 +645,7 @@ describe( 'Link', () => {
 			} );
 
 			it( 'should hide and focus editable on formView#unlink event', () => {
-				return linkFeature.showPanel()
+				return linkFeature._showPanel()
 					.then( () => {
 						formView.fire( 'unlink' );
 
@@ -655,7 +655,7 @@ describe( 'Link', () => {
 			} );
 
 			it( 'should hide and focus editable on formView#cancel event', () => {
-				return linkFeature.showPanel()
+				return linkFeature._showPanel()
 					.then( () => {
 						formView.fire( 'cancel' );
 

--- a/tests/link.js
+++ b/tests/link.js
@@ -79,17 +79,21 @@ describe( 'Link', () => {
 		} );
 
 		it( 'should return promise', () => {
-			// @TODO: test resolved promise.
-			expect( linkFeature.showPanel() ).to.instanceof( Promise );
+			const returned = linkFeature.showPanel();
+
+			expect( returned ).to.instanceof( Promise );
+
+			return returned;
 		} );
 
-		it( 'should add `formView` to the `ContextualBalloon` and attach panel to the selection when text fragment is selected', () => {
+		it( 'should add #formView to the #_balloon and attach the #_balloon to the selection when text fragment is selected', () => {
 			setModelData( editor.document, '<paragraph>f[o]o</paragraph>' );
 			const selectedRange = editorElement.ownerDocument.getSelection().getRangeAt( 0 );
 
 			return linkFeature.showPanel()
 				.then( () => {
 					expect( balloon.visibleView ).to.equal( formView );
+
 					sinon.assert.calledWithExactly( balloonAddSpy, {
 						view: formView,
 						position: {
@@ -100,13 +104,14 @@ describe( 'Link', () => {
 				} );
 		} );
 
-		it( 'should add `formView` to the `ContextualBalloon` and attach panel to the selection when selection is collapsed', () => {
+		it( 'should add #formView to the #_balloon and attach the #_balloon to the selection when selection is collapsed', () => {
 			setModelData( editor.document, '<paragraph>f[]oo</paragraph>' );
 			const selectedRange = editorElement.ownerDocument.getSelection().getRangeAt( 0 );
 
 			return linkFeature.showPanel()
 				.then( () => {
 					expect( balloon.visibleView ).to.equal( formView );
+
 					sinon.assert.calledWithExactly( balloonAddSpy, {
 						view: formView,
 						position: {
@@ -117,8 +122,8 @@ describe( 'Link', () => {
 				} );
 		} );
 
-		it( 'should add `formView` to the `ContextualBalloon` and attach panel to the link element when collapsed selection is inside ' +
-			'link element',
+		it( 'should add #formView to the #_balloon and attach the #_balloon to the link element when collapsed selection is inside ' +
+			'that link',
 		() => {
 			setModelData( editor.document, '<paragraph><$text linkHref="url">f[]oo</$text></paragraph>' );
 			const linkElement = editorElement.querySelector( 'a' );
@@ -126,6 +131,7 @@ describe( 'Link', () => {
 			return linkFeature.showPanel()
 				.then( () => {
 					expect( balloon.visibleView ).to.equal( formView );
+
 					sinon.assert.calledWithExactly( balloonAddSpy, {
 						view: formView,
 						position: {
@@ -136,7 +142,7 @@ describe( 'Link', () => {
 				} );
 		} );
 
-		it( 'should not focus `formView` at default', () => {
+		it( 'should not focus the #formView at default', () => {
 			const spy = testUtils.sinon.spy( formView.urlInputView, 'select' );
 
 			return linkFeature.showPanel()
@@ -145,7 +151,7 @@ describe( 'Link', () => {
 				} );
 		} );
 
-		it( 'should not focus `formView` when is called with `false` parameter', () => {
+		it( 'should not focus the #formView when called with a `false` parameter', () => {
 			const spy = testUtils.sinon.spy( formView.urlInputView, 'select' );
 
 			return linkFeature.showPanel( false )
@@ -154,7 +160,7 @@ describe( 'Link', () => {
 				} );
 		} );
 
-		it( 'should not focus `formView` when is called with `true` parameter while balloon is opened but link form is not visible', () => {
+		it( 'should not focus the #formView when called with a `true` parameter while the balloon is opened but link form is not visible', () => {
 			const spy = testUtils.sinon.spy( formView.urlInputView, 'select' );
 			const viewMock = {
 				ready: true,
@@ -170,7 +176,7 @@ describe( 'Link', () => {
 				} );
 		} );
 
-		it( 'should focus `formView` when is called with `true` parameter', () => {
+		it( 'should focus the #formView when called with a `true` parameter', () => {
 			const spy = testUtils.sinon.spy( formView.urlInputView, 'select' );
 
 			return linkFeature.showPanel( true )
@@ -179,7 +185,7 @@ describe( 'Link', () => {
 				} );
 		} );
 
-		it( 'should focus `formView` when is called with `true` parameter while balloon is opened and linkForm is visible', () => {
+		it( 'should focus the #formView when called with a `true` parameter while the balloon is open and the #formView is visible', () => {
 			const spy = testUtils.sinon.spy( formView.urlInputView, 'select' );
 
 			return linkFeature.showPanel( false )
@@ -189,10 +195,10 @@ describe( 'Link', () => {
 				} );
 		} );
 
-		it( 'should keep editor ui focused when panel is shown with selected form', () => {
+		it( 'should keep the editor ui focused when the #_balloon is shown with the selected form', () => {
 			editor.ui.focusTracker.isFocused = false;
 
-			// Open balloon panel with link inside.
+			// Open the #_balloon with the link inside.
 			return linkFeature.showPanel( true )
 				.then( () => {
 					// Check if editor ui is focused.
@@ -206,33 +212,33 @@ describe( 'Link', () => {
 			return balloon.add( { view: formView } );
 		} );
 
-		it( 'should remove `formView` from the `ContextualBalloon` component', () => {
+		it( 'should remove #formView from the #_balloon', () => {
 			linkFeature.hidePanel();
 			expect( balloon.hasView( formView ) ).to.false;
 		} );
 
-		it( 'should not focus `editable` at default', () => {
+		it( 'should not focus the `editable` by default', () => {
 			const spy = testUtils.sinon.spy( editor.editing.view, 'focus' );
 
 			linkFeature.hidePanel();
 			sinon.assert.notCalled( spy );
 		} );
 
-		it( 'should not focus `editable` when is called with `false` parameter', () => {
+		it( 'should not focus the `editable` when called with a `false` parameter', () => {
 			const spy = testUtils.sinon.spy( editor.editing.view, 'focus' );
 
 			linkFeature.hidePanel( false );
 			sinon.assert.notCalled( spy );
 		} );
 
-		it( 'should focus `editable` when is called with `true` parameter', () => {
+		it( 'should focus the `editable` when called with a `true` parameter', () => {
 			const spy = testUtils.sinon.spy( editor.editing.view, 'focus' );
 
 			linkFeature.hidePanel( true );
 			sinon.assert.calledOnce( spy );
 		} );
 
-		it( 'should do not throw an error when `formView` is not added to the `balloon`', () => {
+		it( 'should not throw an error when #formView is not added to the `balloon`', () => {
 			linkFeature.hidePanel( true );
 
 			expect( () => {
@@ -268,7 +274,7 @@ describe( 'Link', () => {
 			expect( linkButton.isEnabled ).to.be.false;
 		} );
 
-		it( 'should show panel on execute event with selected `formView`', () => {
+		it( 'should show the #_balloon on execute event with the selected #formView', () => {
 			// Method is stubbed because it returns internal promise which can't be returned in test.
 			const spy = testUtils.sinon.stub( linkFeature, 'showPanel', () => {} );
 
@@ -304,7 +310,7 @@ describe( 'Link', () => {
 	} );
 
 	describe( 'keyboard support', () => {
-		it( 'should show panel with selected `formView` on `CTRL+K` keystroke', () => {
+		it( 'should show the #_balloon with selected #formView on `CTRL+K` keystroke', () => {
 			// Method is stubbed because it returns internal promise which can't be returned in test.
 			const spy = testUtils.sinon.stub( linkFeature, 'showPanel', () => {} );
 
@@ -313,7 +319,7 @@ describe( 'Link', () => {
 			sinon.assert.calledWithExactly( spy, true );
 		} );
 
-		it( 'should focus the `formView` on `Tab` key press when panel is open', () => {
+		it( 'should focus the the #formView on `Tab` key press when the #_balloon is open', () => {
 			const keyEvtData = {
 				keyCode: keyCodes.tab,
 				preventDefault: sinon.spy(),
@@ -350,7 +356,7 @@ describe( 'Link', () => {
 				} );
 		} );
 
-		it( 'should hide panel after Esc key press (from editor) and not focus editable', () => {
+		it( 'should hide the #_balloon after Esc key press (from editor) and not focus the editable', () => {
 			const spy = testUtils.sinon.spy( linkFeature, 'hidePanel' );
 			const keyEvtData = {
 				keyCode: keyCodes.esc,
@@ -366,7 +372,7 @@ describe( 'Link', () => {
 			} );
 		} );
 
-		it( 'should not hide panel after Esc key press (from editor) when panel is open but is not visible', () => {
+		it( 'should not hide #_balloon after Esc key press (from editor) when #_balloon is open but is not visible', () => {
 			const spy = testUtils.sinon.spy( linkFeature, 'hidePanel' );
 			const keyEvtData = {
 				keyCode: keyCodes.esc,
@@ -389,7 +395,7 @@ describe( 'Link', () => {
 				} );
 		} );
 
-		it( 'should hide panel after Esc key press (from the form) and focus editable', () => {
+		it( 'should hide the #_balloon after Esc key press (from the form) and focus the editable', () => {
 			const spy = testUtils.sinon.spy( linkFeature, 'hidePanel' );
 			const keyEvtData = {
 				keyCode: keyCodes.esc,
@@ -407,7 +413,7 @@ describe( 'Link', () => {
 	} );
 
 	describe( 'mouse support', () => {
-		it( 'should hide panel and not focus editable on click outside the panel', () => {
+		it( 'should hide #_balloon and not focus editable on click outside the #_balloon', () => {
 			const spy = testUtils.sinon.spy( linkFeature, 'hidePanel' );
 
 			return linkFeature.showPanel( true )
@@ -418,7 +424,7 @@ describe( 'Link', () => {
 				} );
 		} );
 
-		it( 'should not hide panel on click inside the panel', () => {
+		it( 'should not hide #_balloon on click inside the #_balloon', () => {
 			const spy = testUtils.sinon.spy( linkFeature, 'hidePanel' );
 
 			return linkFeature.showPanel( true )

--- a/tests/link.js
+++ b/tests/link.js
@@ -139,7 +139,11 @@ describe( 'Link', () => {
 
 			linkButton.fire( 'execute' );
 
-			expect( selectUrlInputSpy.calledOnce ).to.true;
+			// Focus of url input is called async after internal promise resolve and we are
+			// not able to return this promise.
+			return wait().then( () => {
+				expect( selectUrlInputSpy.calledOnce ).to.true;
+			} );
 		} );
 	} );
 
@@ -185,7 +189,12 @@ describe( 'Link', () => {
 			editor.keystrokes.press( { keyCode: keyCodes.k, ctrlKey: true } );
 
 			expect( balloon.visibleView ).to.equal( formView );
-			expect( selectUrlInputSpy.calledOnce ).to.true;
+
+			// Focus of url input is called async after internal promise resolve and we are
+			// not able to return this promise.
+			return wait().then( () => {
+				expect( selectUrlInputSpy.calledOnce ).to.true;
+			} );
 		} );
 
 		it( 'should not add panel to ContextualBalloon more than once', () => {
@@ -341,7 +350,12 @@ describe( 'Link', () => {
 				observer.fire( 'click', { target: document.body } );
 
 				expect( balloon.visibleView ).to.equal( formView );
-				expect( selectUrlInputSpy.notCalled ).to.true;
+
+				// Focus of url input is called async after internal promise resolve and we are
+				// not able to return this promise.
+				return wait().then( () => {
+					expect( selectUrlInputSpy.notCalled ).to.true;
+				} );
 			} );
 
 			it( 'should keep open and update position until collapsed selection stay inside the same link element', () => {
@@ -569,3 +583,9 @@ describe( 'Link', () => {
 		} );
 	} );
 } );
+
+function wait( delay = 1 ) {
+	return new Promise( ( resolve ) => {
+		setTimeout( () => resolve(), delay );
+	} );
+}

--- a/tests/link.js
+++ b/tests/link.js
@@ -51,6 +51,8 @@ describe( 'Link', () => {
 	} );
 
 	afterEach( () => {
+		editorElement.remove();
+
 		return editor.destroy();
 	} );
 

--- a/tests/link.js
+++ b/tests/link.js
@@ -196,17 +196,6 @@ describe( 'Link', () => {
 					sinon.assert.calledOnce( spy );
 				} );
 		} );
-
-		it( 'should keep the editor ui focused when the #_balloon is shown with the selected form', () => {
-			editor.ui.focusTracker.isFocused = false;
-
-			// Open the #_balloon with the link inside.
-			return linkFeature._showPanel( true )
-				.then( () => {
-					// Check if editor ui is focused.
-					expect( editor.ui.focusTracker.isFocused ).to.true;
-				} );
-		} );
 	} );
 
 	describe( '_hidePanel()', () => {

--- a/tests/link.js
+++ b/tests/link.js
@@ -220,6 +220,19 @@ describe( 'Link', () => {
 			sinon.assert.calledOnce( spy );
 		} );
 
+		it( 'should keep editor ui focused when link form has focus', () => {
+			editor.ui.focusTracker.isFocused = false;
+
+			// Open balloon panel with link inside.
+			linkButton.fire( 'execute' );
+
+			// Be sure that form view is focused.
+			formView.element.dispatchEvent( new Event( 'focus' ) );
+
+			// Check if editor ui is focused.
+			expect( editor.ui.focusTracker.isFocused ).to.true;
+		} );
+
 		describe( 'close listeners', () => {
 			describe( 'keyboard', () => {
 				it( 'should close after Esc key press (from editor) and not focus editable', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Made Link Plugins `#showPanel()` and `#hidePanel()` methods protected. Closes #95. Closes #94.

---

It makes possible to fully test these methods and then test how link uses them without a need to execute them.