### PR TITLE
t/90: Esc key should close the link panel even if none of the form fields is focused

### DIFF
--- a/src/ui/linkformview.js
+++ b/src/ui/linkformview.js
@@ -124,7 +124,10 @@ export default class LinkFormView extends View {
 			attributes: {
 				class: [
 					'ck-link-form',
-				]
+				],
+
+				// https://github.com/ckeditor/ckeditor5-link/issues/90
+				tabindex: '-1'
 			},
 
 			children: [

--- a/tests/ui/linkformview.js
+++ b/tests/ui/linkformview.js
@@ -26,6 +26,7 @@ describe( 'LinkFormView', () => {
 	describe( 'constructor()', () => {
 		it( 'should create element from template', () => {
 			expect( view.element.classList.contains( 'ck-link-form' ) ).to.true;
+			expect( view.element.getAttribute( 'tabindex' ) ).to.equal( '-1' );
 		} );
 
 		it( 'should create child views', () => {

--- a/theme/components/linkform.scss
+++ b/theme/components/linkform.scss
@@ -8,6 +8,11 @@
 		padding: ck-spacing( 'large' );
 		overflow: hidden;
 
+		&:focus {
+			// https://github.com/ckeditor/ckeditor5-link/issues/90
+			outline: none;
+		}
+
 		.ck-label {
 			margin-bottom: ck-spacing( 'small' );
 		}


### PR DESCRIPTION
…ocused. Closes #90.

### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Esc key should close the link panel even if none of the `LinkFormView` fields is focused. Closes #90.

---

### Additional information

Requires https://github.com/ckeditor/ckeditor5-ui/pull/213.
