### PR TITLE
t/109: URL input field should provide a placeholder

### DIFF
--- a/src/ui/linkformview.js
+++ b/src/ui/linkformview.js
@@ -199,6 +199,7 @@ export default class LinkFormView extends View {
 		const labeledInput = new LabeledInputView( this.locale, InputTextView );
 
 		labeledInput.label = t( 'Link URL' );
+		labeledInput.inputView.placeholder = t( 'http://example.com' );
 
 		return labeledInput;
 	}

--- a/tests/ui/linkformview.js
+++ b/tests/ui/linkformview.js
@@ -18,7 +18,7 @@ describe( 'LinkFormView', () => {
 	let view;
 
 	beforeEach( () => {
-		view = new LinkFormView( { t: () => {} } );
+		view = new LinkFormView( { t: () => 'http://example.com' } );
 
 		return view.init();
 	} );
@@ -95,6 +95,12 @@ describe( 'LinkFormView', () => {
 			view.unlinkButtonView.fire( 'execute' );
 
 			expect( spy.calledOnce ).to.true;
+		} );
+
+		describe( 'url input view', () => {
+			it( 'has placeholder', () => {
+				expect( view.urlInputView.inputView.placeholder ).to.equal( 'http://example.com' );
+			} );
 		} );
 
 		describe( 'template', () => {

--- a/tests/ui/linkformview.js
+++ b/tests/ui/linkformview.js
@@ -18,7 +18,7 @@ describe( 'LinkFormView', () => {
 	let view;
 
 	beforeEach( () => {
-		view = new LinkFormView( { t: () => 'http://example.com' } );
+		view = new LinkFormView( { t: ( val ) => val } );
 
 		return view.init();
 	} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: URL input field should provide a placeholder. Closes #109.

---

### Additional information

* Requires https://github.com/ckeditor/ckeditor5-ui/pull/221.
