### PR TITLE
t/93: UnlinkCommand should update its state upon editor load

### DIFF
--- a/src/unlinkcommand.js
+++ b/src/unlinkcommand.js
@@ -25,6 +25,10 @@ export default class UnlinkCommand extends Command {
 
 		// Checks when command should be enabled or disabled.
 		this.listenTo( editor.document.selection, 'change:attribute', () => this.refreshState() );
+
+		// Determine the initial state of the command.
+		// https://github.com/ckeditor/ckeditor5-link/issues/93
+		this.refreshState();
 	}
 
 	/**

--- a/tests/unlinkcommand.js
+++ b/tests/unlinkcommand.js
@@ -41,6 +41,15 @@ describe( 'UnlinkCommand', () => {
 
 			expect( refreshStateSpy.calledOnce ).to.true;
 		} );
+
+		// https://github.com/ckeditor/ckeditor5-link/issues/93
+		it( 'should determine the initial state of the command', () => {
+			const refreshStateSpy = testUtils.sinon.spy( UnlinkCommand.prototype, 'refreshState' );
+
+			new UnlinkCommand( editor );
+
+			expect( refreshStateSpy.calledOnce ).to.true;
+		} );
 	} );
 
 	describe( '_doExecute', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: UnlinkCommand should update its state upon editor load. Closes #93.