### PR TITLE
t/123: URL input value should not be 'undefined' when no link is selected

### DIFF
--- a/src/link.js
+++ b/src/link.js
@@ -243,7 +243,8 @@ export default class Link extends Plugin {
 		// unaltered) and re-opened it without changing the value of the link command (e.g. because they
 		// clicked the same link), they would see the old value instead of the actual value of the command.
 		// https://github.com/ckeditor/ckeditor5-link/issues/78
-		this.formView.urlInputView.inputView.element.value = command.value;
+		// https://github.com/ckeditor/ckeditor5-link/issues/123
+		this.formView.urlInputView.inputView.element.value = command.value || '';
 
 		this.listenTo( showViewDocument, 'render', () => {
 			const renderSelectedLink = this._getSelectedLinkElement();

--- a/tests/link.js
+++ b/tests/link.js
@@ -216,7 +216,7 @@ describe( 'Link', () => {
 		} );
 
 		// https://github.com/ckeditor/ckeditor5-link/issues/78
-		it( 'should make sure the URL input in the #formView always stays in sync with the value of the command', () => {
+		it( 'should make sure the URL input in the #formView always stays in sync with the value of the command (selected link)', () => {
 			setModelData( editor.document, '<paragraph><$text linkHref="url">f[]oo</$text></paragraph>' );
 
 			// Mock some leftover value **in DOM**, e.g. after previous editing.
@@ -225,6 +225,16 @@ describe( 'Link', () => {
 			return linkFeature._showPanel()
 				.then( () => {
 					expect( formView.urlInputView.inputView.element.value ).to.equal( 'url' );
+				} );
+		} );
+
+		// https://github.com/ckeditor/ckeditor5-link/issues/123
+		it( 'should make sure the URL input in the #formView always stays in sync with the value of the command (no link selected)', () => {
+			setModelData( editor.document, '<paragraph>f[]oo</paragraph>' );
+
+			return linkFeature._showPanel()
+				.then( () => {
+					expect( formView.urlInputView.inputView.element.value ).to.equal( '' );
 				} );
 		} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: URL input value should not be 'undefined' when no link is selected. Closes #123.

---

### Additional information

A regression after #119.
