### PR TITLE
t/128: Keyboard listener should check if the command is enabled before opening the balloon

### DIFF
--- a/src/link.js
+++ b/src/link.js
@@ -124,7 +124,11 @@ export default class Link extends Plugin {
 		const t = editor.t;
 
 		// Handle `Ctrl+K` keystroke and show the panel.
-		editor.keystrokes.set( 'CTRL+K', () => this._showPanel( true ) );
+		editor.keystrokes.set( 'CTRL+K', () => {
+			if ( linkCommand.isEnabled ) {
+				this._showPanel( true );
+			}
+		} );
 
 		editor.ui.componentFactory.add( 'link', locale => {
 			const button = new ButtonView( locale );

--- a/src/link.js
+++ b/src/link.js
@@ -24,6 +24,8 @@ import unlinkIcon from '../theme/icons/unlink.svg';
 
 import '../theme/theme.scss';
 
+const linkKeystroke = 'Ctrl+K';
+
 /**
  * The link plugin. It introduces the Link and Unlink buttons and the <kbd>Ctrl+K</kbd> keystroke.
  *
@@ -124,7 +126,7 @@ export default class Link extends Plugin {
 		const t = editor.t;
 
 		// Handle `Ctrl+K` keystroke and show the panel.
-		editor.keystrokes.set( 'CTRL+K', () => {
+		editor.keystrokes.set( linkKeystroke, () => {
 			if ( linkCommand.isEnabled ) {
 				this._showPanel( true );
 			}
@@ -136,7 +138,7 @@ export default class Link extends Plugin {
 			button.isEnabled = true;
 			button.label = t( 'Link' );
 			button.icon = linkIcon;
-			button.keystroke = 'CTRL+K';
+			button.keystroke = linkKeystroke;
 			button.tooltip = true;
 
 			// Bind button to the command.

--- a/tests/link.js
+++ b/tests/link.js
@@ -437,7 +437,7 @@ describe( 'Link', () => {
 	} );
 
 	describe( 'keyboard support', () => {
-		it( 'should show the #_balloon with selected #formView on `CTRL+K` keystroke', () => {
+		it( 'should show the #_balloon with selected #formView on Ctrl+K keystroke', () => {
 			const spy = testUtils.sinon.stub( linkFeature, '_showPanel', () => {} );
 			const command = editor.commands.get( 'link' );
 

--- a/tests/link.js
+++ b/tests/link.js
@@ -439,7 +439,13 @@ describe( 'Link', () => {
 	describe( 'keyboard support', () => {
 		it( 'should show the #_balloon with selected #formView on `CTRL+K` keystroke', () => {
 			const spy = testUtils.sinon.stub( linkFeature, '_showPanel', () => {} );
+			const command = editor.commands.get( 'link' );
 
+			command.isEnabled = false;
+			editor.keystrokes.press( { keyCode: keyCodes.k, ctrlKey: true } );
+			sinon.assert.notCalled( spy );
+
+			command.isEnabled = true;
 			editor.keystrokes.press( { keyCode: keyCodes.k, ctrlKey: true } );
 			sinon.assert.calledWithExactly( spy, true );
 		} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Keyboard listener should check if the command is enabled before opening the balloon. Closes #128.