### PR TITLE
Switched LinkForm to the read-only mode when link and unlink commands are disabled.

### DIFF
--- a/src/link.js
+++ b/src/link.js
@@ -93,7 +93,7 @@ export default class Link extends Plugin {
 		formView.urlInputView.bind( 'value' ).to( linkCommand, 'value' );
 
 		// Form elements should be read-only when corresponding commands are disabled.
-		formView.urlInputView.inputView.bind( 'isReadOnly' ).to( linkCommand, 'isEnabled', value => !value );
+		formView.urlInputView.bind( 'isReadOnly' ).to( linkCommand, 'isEnabled', value => !value );
 		formView.saveButtonView.bind( 'isEnabled' ).to( linkCommand );
 		formView.unlinkButtonView.bind( 'isEnabled' ).to( unlinkCommand );
 

--- a/src/link.js
+++ b/src/link.js
@@ -87,8 +87,15 @@ export default class Link extends Plugin {
 	_createForm() {
 		const editor = this.editor;
 		const formView = new LinkFormView( editor.locale );
+		const linkCommand = editor.commands.get( 'link' );
+		const unlinkCommand = editor.commands.get( 'unlink' );
 
-		formView.urlInputView.bind( 'value' ).to( editor.commands.get( 'link' ), 'value' );
+		formView.urlInputView.bind( 'value' ).to( linkCommand, 'value' );
+
+		// Switch form to the read-only mode when commands are disabled.
+		formView.urlInputView.inputView.bind( 'isReadOnly' ).to( linkCommand, 'isEnabled', value => !value );
+		formView.saveButtonView.bind( 'isEnabled' ).to( linkCommand );
+		formView.unlinkButtonView.bind( 'isEnabled' ).to( unlinkCommand );
 
 		// Execute link command after clicking on formView `Save` button.
 		this.listenTo( formView, 'submit', () => {

--- a/src/link.js
+++ b/src/link.js
@@ -92,7 +92,7 @@ export default class Link extends Plugin {
 
 		formView.urlInputView.bind( 'value' ).to( linkCommand, 'value' );
 
-		// Switch form to the read-only mode when commands are disabled.
+		// Form elements should be read-only when corresponding commands are disabled.
 		formView.urlInputView.inputView.bind( 'isReadOnly' ).to( linkCommand, 'isEnabled', value => !value );
 		formView.saveButtonView.bind( 'isEnabled' ).to( linkCommand );
 		formView.unlinkButtonView.bind( 'isEnabled' ).to( unlinkCommand );

--- a/tests/link.js
+++ b/tests/link.js
@@ -183,7 +183,7 @@ describe( 'Link', () => {
 			editor.commands.get( 'link' ).isEnabled = true;
 			editor.commands.get( 'unlink' ).isEnabled = true;
 
-			expect( formView.urlInputView.inputView.isReadOnly ).to.false;
+			expect( formView.urlInputView.isReadOnly ).to.false;
 			expect( formView.saveButtonView.isEnabled ).to.true;
 			expect( formView.unlinkButtonView.isEnabled ).to.true;
 			expect( formView.cancelButtonView.isEnabled ).to.true;
@@ -191,7 +191,7 @@ describe( 'Link', () => {
 			editor.commands.get( 'link' ).isEnabled = false;
 			editor.commands.get( 'unlink' ).isEnabled = false;
 
-			expect( formView.urlInputView.inputView.isReadOnly ).to.true;
+			expect( formView.urlInputView.isReadOnly ).to.true;
 			expect( formView.saveButtonView.isEnabled ).to.false;
 			expect( formView.unlinkButtonView.isEnabled ).to.false;
 			expect( formView.cancelButtonView.isEnabled ).to.true;

--- a/tests/link.js
+++ b/tests/link.js
@@ -175,6 +175,28 @@ describe( 'Link', () => {
 			sinon.assert.calledOnce( spy );
 		} );
 
+		it( 'should disable #formView elements when link and unlink commands are disabled', () => {
+			setModelData( editor.document, '<paragraph>f[o]o</paragraph>' );
+
+			linkFeature._showPanel();
+
+			editor.commands.get( 'link' ).isEnabled = true;
+			editor.commands.get( 'unlink' ).isEnabled = true;
+
+			expect( formView.urlInputView.inputView.isReadOnly ).to.false;
+			expect( formView.saveButtonView.isEnabled ).to.true;
+			expect( formView.unlinkButtonView.isEnabled ).to.true;
+			expect( formView.cancelButtonView.isEnabled ).to.true;
+
+			editor.commands.get( 'link' ).isEnabled = false;
+			editor.commands.get( 'unlink' ).isEnabled = false;
+
+			expect( formView.urlInputView.inputView.isReadOnly ).to.true;
+			expect( formView.saveButtonView.isEnabled ).to.false;
+			expect( formView.unlinkButtonView.isEnabled ).to.false;
+			expect( formView.cancelButtonView.isEnabled ).to.true;
+		} );
+
 		// https://github.com/ckeditor/ckeditor5-link/issues/53
 		it( 'should set formView.unlinkButtonView#isVisible depending on the selection in a link or not', () => {
 			setModelData( editor.document, '<paragraph>f[]oo</paragraph>' );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Switched `LinkFormView` to the read-only mode when `LinkCommand` and `UnlinkCommand` are disabled. Closes #135.

---

Requires https://github.com/ckeditor/ckeditor5-ui/pull/267.