### PR TITLE
t/141: Unlink button in the balloon should be visible when a link is partially selected

### DIFF
--- a/src/link.js
+++ b/src/link.js
@@ -241,14 +241,15 @@ export default class Link extends Plugin {
 	 */
 	_showPanel( focusInput ) {
 		const editor = this.editor;
-		const command = editor.commands.get( 'link' );
+		const linkCommand = editor.commands.get( 'link' );
+		const unlinkCommand = editor.commands.get( 'unlink' );
 		const editing = editor.editing;
 		const showViewDocument = editing.view;
 		const showIsCollapsed = showViewDocument.selection.isCollapsed;
 		const showSelectedLink = this._getSelectedLinkElement();
 
 		// https://github.com/ckeditor/ckeditor5-link/issues/53
-		this.formView.unlinkButtonView.isVisible = !!showSelectedLink;
+		this.formView.unlinkButtonView.isVisible = unlinkCommand.isEnabled;
 
 		// Make sure that each time the panel shows up, the URL field remains in sync with the value of
 		// the command. If the user typed in the input, then canceled the balloon (`urlInputView#value` stays
@@ -256,7 +257,7 @@ export default class Link extends Plugin {
 		// clicked the same link), they would see the old value instead of the actual value of the command.
 		// https://github.com/ckeditor/ckeditor5-link/issues/78
 		// https://github.com/ckeditor/ckeditor5-link/issues/123
-		this.formView.urlInputView.inputView.element.value = command.value || '';
+		this.formView.urlInputView.inputView.element.value = linkCommand.value || '';
 
 		this.listenTo( showViewDocument, 'render', () => {
 			const renderSelectedLink = this._getSelectedLinkElement();

--- a/tests/link.js
+++ b/tests/link.js
@@ -208,6 +208,11 @@ describe( 'Link', () => {
 
 			linkFeature._showPanel();
 			expect( formView.unlinkButtonView.isVisible ).to.be.true;
+
+			setModelData( editor.document, '<paragraph><$text linkHref="url">[fo]o</$text></paragraph>' );
+
+			linkFeature._showPanel();
+			expect( formView.unlinkButtonView.isVisible ).to.be.true;
 		} );
 
 		// https://github.com/ckeditor/ckeditor5-link/issues/78


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Unlink button in the balloon should be visible when a link is partially selected. Closes #141.
