### PR TITLE
t/ckeditor5/447: The Link keystrokes should properly integrate with the List feature. Improved balloon positioning

### DIFF
--- a/src/link.js
+++ b/src/link.js
@@ -215,7 +215,12 @@ export default class Link extends Plugin {
 				this.formView.focus();
 				cancel();
 			}
-		}, { priority: 'high' } );
+		}, {
+			// Use the high priority because the link UI navigation is more important
+			// than other feature's actions, e.g. list indentation.
+			// https://github.com/ckeditor/ckeditor5-link/issues/146
+			priority: 'high'
+		} );
 
 		// Close the panel on the Esc key press when the editable has focus and the balloon is visible.
 		this.editor.keystrokes.set( 'Esc', ( data, cancel ) => {

--- a/src/link.js
+++ b/src/link.js
@@ -276,14 +276,9 @@ export default class Link extends Plugin {
 			//  * there was no link element in the first place, i.e. creating a new link
 			else {
 				// If still in a link element, simply update the position of the balloon.
-				if ( renderSelectedLink ) {
-					this._balloon.updatePosition();
-				}
 				// If there was no link, upon #render, the balloon must be moved
 				// to the new position in the editing view (a new native DOM range).
-				else {
-					this._balloon.updatePosition( this._getBalloonPositionData() );
-				}
+				this._balloon.updatePosition( this._getBalloonPositionData() );
 			}
 		} );
 

--- a/src/link.js
+++ b/src/link.js
@@ -213,7 +213,7 @@ export default class Link extends Plugin {
 				this.formView.focus();
 				cancel();
 			}
-		} );
+		}, { priority: 'high' } );
 
 		// Close the panel on the Esc key press when the editable has focus and the balloon is visible.
 		this.editor.keystrokes.set( 'Esc', ( data, cancel ) => {

--- a/tests/link.js
+++ b/tests/link.js
@@ -267,8 +267,7 @@ describe( 'Link', () => {
 
 				sinon.assert.calledOnce( spy );
 				sinon.assert.calledWithExactly( spy, {
-					target: viewDocument.domConverter.mapViewToDom( root.getChild( 0 ).getChild( 0 ) ),
-					limiter: editorElement
+					target: viewDocument.domConverter.mapViewToDom( root.getChild( 0 ).getChild( 0 ) )
 				} );
 			} );
 

--- a/tests/link.js
+++ b/tests/link.js
@@ -268,7 +268,10 @@ describe( 'Link', () => {
 				viewDocument.render();
 
 				sinon.assert.calledOnce( spy );
-				sinon.assert.calledWithExactly( spy );
+				sinon.assert.calledWithExactly( spy, {
+					target: viewDocument.domConverter.mapViewToDom( root.getChild( 0 ).getChild( 0 ) ),
+					limiter: editorElement
+				} );
 			} );
 
 			// https://github.com/ckeditor/ckeditor5-link/issues/113
@@ -484,6 +487,11 @@ describe( 'Link', () => {
 				stopPropagation: sinon.spy()
 			};
 
+			const normalPriorityTabCallbackSpy = sinon.spy();
+			const highestPriorityTabCallbackSpy = sinon.spy();
+			editor.keystrokes.set( 'Tab', normalPriorityTabCallbackSpy );
+			editor.keystrokes.set( 'Tab', highestPriorityTabCallbackSpy, { priority: 'highest' } );
+
 			// Balloon is invisible, form not focused.
 			formView.focusTracker.isFocused = false;
 
@@ -493,6 +501,8 @@ describe( 'Link', () => {
 			sinon.assert.notCalled( keyEvtData.preventDefault );
 			sinon.assert.notCalled( keyEvtData.stopPropagation );
 			sinon.assert.notCalled( spy );
+			sinon.assert.calledOnce( normalPriorityTabCallbackSpy );
+			sinon.assert.calledOnce( highestPriorityTabCallbackSpy );
 
 			// Balloon is visible, form focused.
 			linkFeature._showPanel( true );
@@ -502,6 +512,8 @@ describe( 'Link', () => {
 			sinon.assert.notCalled( keyEvtData.preventDefault );
 			sinon.assert.notCalled( keyEvtData.stopPropagation );
 			sinon.assert.notCalled( spy );
+			sinon.assert.calledTwice( normalPriorityTabCallbackSpy );
+			sinon.assert.calledTwice( highestPriorityTabCallbackSpy );
 
 			// Balloon is still visible, form not focused.
 			formView.focusTracker.isFocused = false;
@@ -510,6 +522,8 @@ describe( 'Link', () => {
 			sinon.assert.calledOnce( keyEvtData.preventDefault );
 			sinon.assert.calledOnce( keyEvtData.stopPropagation );
 			sinon.assert.calledOnce( spy );
+			sinon.assert.calledTwice( normalPriorityTabCallbackSpy );
+			sinon.assert.calledThrice( highestPriorityTabCallbackSpy );
 		} );
 
 		it( 'should hide the #_balloon after Esc key press (from editor) and not focus the editable', () => {

--- a/tests/ui/linkformview.js
+++ b/tests/ui/linkformview.js
@@ -136,7 +136,7 @@ describe( 'LinkFormView', () => {
 		} );
 
 		describe( 'activates keyboard navigation for the toolbar', () => {
-			it( 'so "tab" the next focusable item', () => {
+			it( 'so "tab" focuses the next focusable item', () => {
 				const keyEvtData = {
 					keyCode: keyCodes.tab,
 					preventDefault: sinon.spy(),


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: The Link keystrokes should properly integrate with the List feature. Improved balloon positioning. Closes #146.

---

### Additional information

* Requires https://github.com/ckeditor/ckeditor5-core/pull/102.
