### PR TITLE
t/145: The URL input should span the width of the balloon

### DIFF
--- a/theme/components/linkform.scss
+++ b/theme/components/linkform.scss
@@ -13,6 +13,11 @@
 			outline: none;
 		}
 
+		.ck-input-text {
+			// https://github.com/ckeditor/ckeditor5-link/issues/145
+			width: 100%;
+		}
+
 		.ck-label {
 			margin-bottom: ck-spacing( 'tiny' );
 		}
@@ -24,12 +29,17 @@
 			.ck-button {
 				float: right;
 
+				// "Save" and "Cancel" buttons.
 				& + .ck-button {
 					margin-right: ck-spacing( 'medium' );
+				}
 
-					& + .ck-button {
-						float: left;
-					}
+				// The "Unlink" button.
+				&:last-child {
+					float: left;
+
+					// https://github.com/ckeditor/ckeditor5-link/issues/145
+					margin-right: 4 * ck-spacing( 'medium' );
 				}
 			}
 		}


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: The URL input should span the width of the balloon. Closes #145.

---

<img width="590" alt="screen shot 2017-09-08 at 15 37 33" src="https://user-images.githubusercontent.com/1099479/30214239-f2e021dc-94ab-11e7-872a-5332337ce350.png">
