### PR TITLE
Prevent default browser actions on CTRL+K

### DIFF
--- a/src/link.js
+++ b/src/link.js
@@ -133,8 +133,7 @@ export default class Link extends Plugin {
 
 		// Handle the `Ctrl+K` keystroke and show the panel.
 		editor.keystrokes.set( linkKeystroke, ( keyEvtData, cancel ) => {
-			// Prevent focusing the search bar in FF. #153.
-			// Prevent opening new tab in Edge. #154.
+			// Prevent focusing the search bar in FF and opening new tab in Edge. #153, #154.
 			cancel();
 
 			if ( linkCommand.isEnabled ) {

--- a/src/link.js
+++ b/src/link.js
@@ -132,7 +132,11 @@ export default class Link extends Plugin {
 		const t = editor.t;
 
 		// Handle the `Ctrl+K` keystroke and show the panel.
-		editor.keystrokes.set( linkKeystroke, () => {
+		editor.keystrokes.set( linkKeystroke, ( keyEvtData, stop ) => {
+			// Stop the event in the DOM to prevent default browser action.
+			// See https://github.com/ckeditor/ckeditor5-link/issues/153.
+			stop();
+
 			if ( linkCommand.isEnabled ) {
 				this._showPanel( true );
 			}

--- a/src/link.js
+++ b/src/link.js
@@ -133,8 +133,8 @@ export default class Link extends Plugin {
 
 		// Handle the `Ctrl+K` keystroke and show the panel.
 		editor.keystrokes.set( linkKeystroke, ( keyEvtData, cancel ) => {
-			// Stop the event in the DOM to prevent default browser action.
-			// See https://github.com/ckeditor/ckeditor5-link/issues/153.
+			// Prevent focusing the search bar in FF. #153.
+			// Prevent opening new tab in Edge. #154.
 			cancel();
 
 			if ( linkCommand.isEnabled ) {

--- a/src/link.js
+++ b/src/link.js
@@ -132,10 +132,10 @@ export default class Link extends Plugin {
 		const t = editor.t;
 
 		// Handle the `Ctrl+K` keystroke and show the panel.
-		editor.keystrokes.set( linkKeystroke, ( keyEvtData, stop ) => {
+		editor.keystrokes.set( linkKeystroke, ( keyEvtData, cancel ) => {
 			// Stop the event in the DOM to prevent default browser action.
 			// See https://github.com/ckeditor/ckeditor5-link/issues/153.
-			stop();
+			cancel();
 
 			if ( linkCommand.isEnabled ) {
 				this._showPanel( true );

--- a/tests/link.js
+++ b/tests/link.js
@@ -460,7 +460,7 @@ describe( 'Link', () => {
 			sinon.assert.calledWithExactly( spy, true );
 		} );
 
-		it( 'should show prevent default actions on Ctrl+K keystroke', () => {
+		it( 'should prevent default action on Ctrl+K keystroke', () => {
 			const preventDefaultSpy = sinon.spy();
 			const stopPropagationSpy = sinon.spy();
 

--- a/tests/link.js
+++ b/tests/link.js
@@ -442,12 +442,37 @@ describe( 'Link', () => {
 			const command = editor.commands.get( 'link' );
 
 			command.isEnabled = false;
-			editor.keystrokes.press( { keyCode: keyCodes.k, ctrlKey: true } );
+			editor.keystrokes.press( {
+				keyCode: keyCodes.k,
+				ctrlKey: true,
+				preventDefault: sinon.spy(),
+				stopPropagation: sinon.spy()
+			} );
 			sinon.assert.notCalled( spy );
 
 			command.isEnabled = true;
-			editor.keystrokes.press( { keyCode: keyCodes.k, ctrlKey: true } );
+			editor.keystrokes.press( {
+				keyCode: keyCodes.k,
+				ctrlKey: true,
+				preventDefault: sinon.spy(),
+				stopPropagation: sinon.spy()
+			} );
 			sinon.assert.calledWithExactly( spy, true );
+		} );
+
+		it( 'should show prevent default actions on Ctrl+K keystroke', () => {
+			const preventDefaultSpy = sinon.spy();
+			const stopPropagationSpy = sinon.spy();
+
+			editor.keystrokes.press( {
+				keyCode: keyCodes.k,
+				ctrlKey: true,
+				preventDefault: preventDefaultSpy,
+				stopPropagation: stopPropagationSpy
+			} );
+
+			sinon.assert.calledOnce( preventDefaultSpy );
+			sinon.assert.calledOnce( stopPropagationSpy );
 		} );
 
 		it( 'should focus the the #formView on `Tab` key press when the #_balloon is open', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Prevented default browser actions on CTRL+K. Closes #153. Closes #154.