### PR TITLE
Link feature was creating empty text nodes with linkHref attribute

### DIFF
--- a/src/linkcommand.js
+++ b/src/linkcommand.js
@@ -73,7 +73,9 @@ export default class LinkCommand extends Command {
 					writer.setSelection( linkRange );
 				}
 				// If not then insert text node with `linkHref` attribute in place of caret.
-				else {
+				// However, since selection in collapsed, attribute value will be used as data for text node.
+				// So, if `href` is empty, do not create text node.
+				else if ( href !== '' ) {
 					const attributes = toMap( selection.getAttributes() );
 
 					attributes.set( 'linkHref', href );

--- a/tests/linkcommand.js
+++ b/tests/linkcommand.js
@@ -249,6 +249,14 @@ describe( 'LinkCommand', () => {
 
 				expect( getData( model ) ).to.equal( '<p>foo[]bar</p>' );
 			} );
+
+			it( 'should not insert text node if link is empty', () => {
+				setData( model, '<p>foo[]bar</p>' );
+
+				command.execute( '' );
+
+				expect( getData( model ) ).to.equal( '<p>foo[]bar</p>' );
+			} );
 		} );
 	} );
 } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Link feature was creating empty text nodes with `linkHref` attribute. Closes #169.