### PR TITLE
Feature: Enabled two-step caret movement for `linkHref` attribute.

### DIFF
--- a/src/link.js
+++ b/src/link.js
@@ -15,6 +15,7 @@ import { isLinkElement } from './utils';
 import ContextualBalloon from '@ckeditor/ckeditor5-ui/src/panel/balloon/contextualballoon';
 
 import clickOutsideHandler from '@ckeditor/ckeditor5-ui/src/bindings/clickoutsidehandler';
+import bindTwoStepCaretToAttribute from '@ckeditor/ckeditor5-engine/src/utils/bindtwostepcarettoattribute';
 
 import ButtonView from '@ckeditor/ckeditor5-ui/src/button/buttonview';
 import LinkFormView from './ui/linkformview';
@@ -82,6 +83,9 @@ export default class Link extends Plugin {
 
 		// Attach lifecycle actions to the the balloon.
 		this._enableUserBalloonInteractions();
+
+		// Enable two-step caret movement for `linkHref` attribute.
+		bindTwoStepCaretToAttribute( editor.editing.view, editor.model, this, 'linkHref' );
 	}
 
 	/**

--- a/tests/link.js
+++ b/tests/link.js
@@ -69,7 +69,7 @@ describe( 'Link', () => {
 		expect( editor.plugins.get( ContextualBalloon ) ).to.be.instanceOf( ContextualBalloon );
 	} );
 
-	describe( 'init', () => {
+	describe( 'init()', () => {
 		it( 'should register click observer', () => {
 			expect( editor.editing.view.getObserver( ClickObserver ) ).to.be.instanceOf( ClickObserver );
 		} );
@@ -80,6 +80,26 @@ describe( 'Link', () => {
 
 		it( 'should create #formView', () => {
 			expect( formView ).to.be.instanceOf( LinkFormView );
+		} );
+
+		it( 'should bind two-step caret movement to `linkHref` attribute', () => {
+			// Let's check only the minimum to not duplicated `bindTwoStepCaretToAttribute()` tests.
+			// Testing minimum is better then testing using spies that might give false positive results.
+
+			// Put selection before the link element.
+			setModelData( editor.model, '<paragraph>foo[]<$text linkHref="url">b</$text>ar</paragraph>' );
+
+			// The selection's gravity is not overridden because selection land here not as a result of `keydown`.
+			expect( editor.model.document.selection.isGravityOverridden ).to.false;
+
+			// So let's simulate `keydown` event.
+			editor.editing.view.document.fire( 'keydown', {
+				keyCode: keyCodes.arrowright,
+				preventDefault: () => {},
+				domTarget: document.body
+			} );
+
+			expect( editor.model.document.selection.isGravityOverridden ).to.true;
 		} );
 
 		describe( 'link toolbar button', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Added two-step caret movement for `linkHref` attribute. Closes #72.