### PR TITLE
Open link balloon on first click

### DIFF
--- a/src/linkediting.js
+++ b/src/linkediting.js
@@ -10,8 +10,7 @@
 import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
 import {
 	downcastAttributeToElement,
-	downcastMarkerToHighlight,
-	createViewElementFromHighlightDescriptor
+	downcastMarkerToHighlight
 } from '@ckeditor/ckeditor5-engine/src/conversion/downcast-converters';
 import { upcastElementToAttribute } from '@ckeditor/ckeditor5-engine/src/conversion/upcast-converters';
 import LinkCommand from './linkcommand';
@@ -20,8 +19,6 @@ import { createLinkElement } from './utils';
 import bindTwoStepCaretToAttribute from '@ckeditor/ckeditor5-engine/src/utils/bindtwostepcarettoattribute';
 import findLinkRange from './findlinkrange';
 import '../theme/link.css';
-import DocumentSelection from '@ckeditor/ckeditor5-engine/src/model/documentselection';
-import ModelSelection from '@ckeditor/ckeditor5-engine/src/model/selection';
 
 /**
  * The link engine feature.
@@ -81,6 +78,7 @@ export default class LinkEditing extends Plugin {
 		const highlightDescriptor = {
 			id: 'linkBoundaries',
 			class: 'ck-link_selected',
+			// Priority higher than link priority, but lower than default one.
 			priority: 7
 		};
 
@@ -110,30 +108,6 @@ export default class LinkEditing extends Plugin {
 			}
 
 			return false;
-		} );
-
-		// Custom converter for selection's "linkHref" attribute - when collapsed selection has this attribute it is
-		// wrapped with <span> similar to that used by highlighting mechanism. This <span> will be merged together with
-		// highlight wrapper. This prevents link splitting When selection is at the beginning or at the end of the link.
-		// Without this converter:
-		//
-		//		<a href="url">{}</a><span class="ck-link_selected"><a href="url">foo</a></span>
-		//
-		// When converter is applied:
-		//
-		//		<span class="ck-link_selected"><a href="url">{}foo</a></span>
-		editor.editing.downcastDispatcher.on( 'attribute:linkHref', ( evt, data, conversionApi ) => {
-			const selection = data.item;
-
-			if ( !( selection instanceof DocumentSelection || selection instanceof ModelSelection ) || !selection.isCollapsed ) {
-				return;
-			}
-
-			const writer = conversionApi.writer;
-			const viewSelection = writer.document.selection;
-			const wrapper = createViewElementFromHighlightDescriptor( highlightDescriptor );
-
-			conversionApi.writer.wrap( viewSelection.getFirstRange(), wrapper );
 		} );
 	}
 }

--- a/src/linkediting.js
+++ b/src/linkediting.js
@@ -81,7 +81,7 @@ export default class LinkEditing extends Plugin {
 		const highlightDescriptor = {
 			id: 'linkBoundaries',
 			class: 'ck-link_selected',
-			priority: 1
+			priority: 7
 		};
 
 		// Convert linkBoundaries marker to view highlight.

--- a/tests/linkediting.js
+++ b/tests/linkediting.js
@@ -166,7 +166,7 @@ describe( 'LinkEditing', () => {
 			);
 
 			expect( getViewData( view ) ).to.equal(
-				'<p>foo <span class="ck-link_selected"><a href="url">b{}ar</a></span> baz</p>'
+				'<p>foo <a href="url"><span class="ck-link_selected">b{}ar</span></a> baz</p>'
 			);
 		} );
 
@@ -188,7 +188,7 @@ describe( 'LinkEditing', () => {
 			expect( marker.getEnd().path ).to.deep.equal( [ 0, 7 ] );
 
 			expect( getViewData( view ) ).to.equal(
-				'<p>foo <span class="ck-link_selected"><a href="url">{}bar</a></span> baz</p>'
+				'<p>foo <a href="url">[]<span class="ck-link_selected">bar</span></a> baz</p>'
 			);
 		} );
 
@@ -204,7 +204,7 @@ describe( 'LinkEditing', () => {
 			expect( marker.getEnd().path ).to.deep.equal( [ 0, 7 ] );
 
 			expect( getViewData( view ) ).to.equal(
-				'<p>foo <span class="ck-link_selected"><a href="url">bar{}</a></span> baz</p>'
+				'<p>foo <a href="url"><span class="ck-link_selected">bar</span>[]</a> baz</p>'
 			);
 		} );
 
@@ -233,7 +233,7 @@ describe( 'LinkEditing', () => {
 			);
 
 			expect( getViewData( view ) ).to.equal(
-				'<p>foo <span class="ck-link_selected"><a href="url">li{}nk</a></span> baz</p>'
+				'<p>foo <a href="url"><span class="ck-link_selected">li{}nk</span></a> baz</p>'
 			);
 
 			expect( model.markers.has( 'linkBoundaries' ) ).to.be.true;
@@ -251,7 +251,7 @@ describe( 'LinkEditing', () => {
 			);
 
 			expect( getViewData( view ) ).to.equal(
-				'<p>foo <span class="ck-link_selected"><a href="url">li{}nk</a></span> baz</p>'
+				'<p>foo <a href="url"><span class="ck-link_selected">li{}nk</span></a> baz</p>'
 			);
 
 			expect( model.markers.has( 'linkBoundaries' ) ).to.be.true;
@@ -259,7 +259,7 @@ describe( 'LinkEditing', () => {
 
 			expect( model.markers.has( 'linkBoundaries' ) ).to.be.true;
 			expect( getViewData( view ) ).to.equal(
-				'<p>foo <span class="ck-link_selected"><a href="url">l{}ink</a></span> baz</p>'
+				'<p>foo <a href="url"><span class="ck-link_selected">l{}ink</span></a> baz</p>'
 			);
 		} );
 	} );

--- a/tests/linkui.js
+++ b/tests/linkui.js
@@ -250,12 +250,12 @@ describe( 'LinkUI', () => {
 				const spy = testUtils.sinon.stub( balloon, 'updatePosition' ).returns( {} );
 
 				expect( getViewData( view ) ).to.equal(
-					'<p><span class="ck-link_selected"><a href="url">f{}oo</a></span></p>'
+					'<p><a href="url"><span class="ck-link_selected">f{}oo</span></a></p>'
 				);
 
 				const root = viewDocument.getRoot();
-				const linkElement = root.getChild( 0 ).getChild( 0 ).getChild( 0 );
-				const text = linkElement.getChild( 0 );
+				const linkElement = root.getChild( 0 ).getChild( 0 );
+				const text = linkElement.getChild( 0 ).getChild( 0 );
 
 				// Move selection to foo[].
 				view.change( writer => {
@@ -319,7 +319,7 @@ describe( 'LinkUI', () => {
 				const spyUpdate = testUtils.sinon.stub( balloon, 'updatePosition' ).returns( {} );
 				const spyHide = testUtils.sinon.spy( linkUIFeature, '_hideUI' );
 
-				expect( getViewData( view ) ).to.equal( '<p><span class="ck-link_selected"><a href="url">f{}oo</a></span></p>' );
+				expect( getViewData( view ) ).to.equal( '<p><a href="url"><span class="ck-link_selected">f{}oo</span></a></p>' );
 
 				const root = viewDocument.getRoot();
 				const text = root.getChild( 0 ).getChild( 0 ).getChild( 0 ).getChild( 0 );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Fixed issue with balloon panel not showing when link is clicked for the first time. Closes #176.

---

### Additional information
I've removed selection position wrapping inside a link, it was causing problems when typing at the link boundaries. Now filler appear there but we decided that it's enough solution for now.