### PR TITLE
t/ckeditor5/1336: Added names to the plugins that expose a public API

### DIFF
--- a/src/linkui.js
+++ b/src/linkui.js
@@ -41,6 +41,13 @@ export default class LinkUI extends Plugin {
 	/**
 	 * @inheritDoc
 	 */
+	static get pluginName() {
+		return 'LinkUI';
+	}
+
+	/**
+	 * @inheritDoc
+	 */
 	init() {
 		const editor = this.editor;
 

--- a/tests/linkui.js
+++ b/tests/linkui.js
@@ -57,6 +57,10 @@ describe( 'LinkUI', () => {
 		return editor.destroy();
 	} );
 
+	it( 'should be named', () => {
+		expect( LinkUI.pluginName ).to.equal( 'LinkUI' );
+	} );
+
 	it( 'should load ContextualBalloon', () => {
 		expect( editor.plugins.get( ContextualBalloon ) ).to.be.instanceOf( ContextualBalloon );
 	} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Added names to the plugins that expose a public API (see ckeditor/ckeditor5#1336).

---

### Additional information

Part of https://github.com/ckeditor/ckeditor5/issues/1336.
