### PR TITLE
Improved focus managing before removing the active element from the DOM

### DIFF
--- a/src/linkui.js
+++ b/src/linkui.js
@@ -306,6 +306,11 @@ export default class LinkUI extends Plugin {
 	 */
 	_removeFormView() {
 		if ( this._isFormInPanel ) {
+			// Blur the input element before removing it from DOM.
+			// See https://github.com/ckeditor/ckeditor5/issues/1501.
+			// Focusing editable before removing FormView makes balloon flickering.
+			this.formView.saveButtonView.focus();
+
 			this._balloon.remove( this.formView );
 
 			// Because the form has an input which has focus, the focus must be brought back

--- a/src/linkui.js
+++ b/src/linkui.js
@@ -365,14 +365,16 @@ export default class LinkUI extends Plugin {
 
 		this.stopListening( editor.ui, 'update' );
 
+		// Make sure the focus always gets back to the editable
+		// before removing currently focused views.
+		// See https://github.com/ckeditor/ckeditor5-link/issues/193.
+		editor.editing.view.focus();
+
 		// Remove form first because it's on top of the stack.
 		this._removeFormView();
 
 		// Then remove the actions view because it's beneath the form.
 		this._balloon.remove( this.actionsView );
-
-		// Make sure the focus always gets back to the editable.
-		editor.editing.view.focus();
 	}
 
 	/**

--- a/src/linkui.js
+++ b/src/linkui.js
@@ -313,9 +313,8 @@ export default class LinkUI extends Plugin {
 	 */
 	_removeFormView() {
 		if ( this._isFormInPanel ) {
-			// Blur the input element before removing it from DOM.
+			// Blur the input element before removing it from DOM to prevent issues in some browsers.
 			// See https://github.com/ckeditor/ckeditor5/issues/1501.
-			// Focusing editable before removing FormView makes balloon flickering.
 			this.formView.saveButtonView.focus();
 
 			this._balloon.remove( this.formView );
@@ -377,9 +376,8 @@ export default class LinkUI extends Plugin {
 
 		this.stopListening( editor.ui, 'update' );
 
-		// Make sure the focus always gets back to the editable
-		// before removing currently focused views.
-		// See https://github.com/ckeditor/ckeditor5-link/issues/193.
+		// Make sure the focus always gets back to the editable _before_ removing the focused form view.
+		// Doing otherwise causes issues in some browsers. See https://github.com/ckeditor/ckeditor5-link/issues/193.
 		editor.editing.view.focus();
 
 		// Remove form first because it's on top of the stack.

--- a/tests/linkui.js
+++ b/tests/linkui.js
@@ -829,6 +829,18 @@ describe( 'LinkUI', () => {
 				expect( balloon.visibleView ).to.equal( actionsView );
 				expect( focusEditableSpy.calledOnce ).to.be.true;
 			} );
+
+			// https://github.com/ckeditor/ckeditor5/issues/1501
+			it( 'should blur url input element before hiding the view', () => {
+				linkUIFeature._showUI();
+
+				const focusSpy = testUtils.sinon.spy( formView.saveButtonView, 'focus' );
+				const removeSpy = testUtils.sinon.spy( balloon, 'remove' );
+
+				formView.fire( 'cancel' );
+
+				expect( focusSpy.calledBefore( removeSpy ) ).to.equal( true );
+			} );
 		} );
 	} );
 } );

--- a/tests/linkui.js
+++ b/tests/linkui.js
@@ -416,6 +416,16 @@ describe( 'LinkUI', () => {
 			sinon.assert.calledTwice( spy );
 		} );
 
+		// https://github.com/ckeditor/ckeditor5-link/issues/193
+		it( 'should focus the `editable` before before removing elements from the balloon', () => {
+			const focusSpy = testUtils.sinon.spy( editor.editing.view, 'focus' );
+			const removeSpy = testUtils.sinon.spy( balloon, 'remove' );
+
+			linkUIFeature._hideUI();
+
+			expect( focusSpy.calledBefore( removeSpy ) ).to.equal( true );
+		} );
+
 		it( 'should not throw an error when views are not in the `balloon`', () => {
 			linkUIFeature._hideUI();
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Improved focus managing before removing the active element from the DOM. Closes https://github.com/ckeditor/ckeditor5/issues/1501.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
