### PR TITLE
Use model.insertContent instead of model.Writer.insert

### DIFF
--- a/src/linkcommand.js
+++ b/src/linkcommand.js
@@ -81,7 +81,7 @@ export default class LinkCommand extends Command {
 
 					const node = writer.createText( href, attributes );
 
-					writer.insert( node, position );
+					model.insertContent( node, position );
 
 					// Create new range wrapping created node.
 					writer.setSelection( writer.createRangeOn( node ) );

--- a/tests/linkcommand.js
+++ b/tests/linkcommand.js
@@ -19,7 +19,7 @@ describe( 'LinkCommand', () => {
 
 				model.schema.extend( '$text', {
 					allowIn: '$root',
-					allowAttributes: 'linkHref'
+					allowAttributes: [ 'linkHref', 'bold' ]
 				} );
 
 				model.schema.register( 'p', { inheritAllFrom: '$block' } );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: `Use model.insertContent` instead of `model.Writer.insert`. Closes #224.