### PR TITLE
Link balloon will not be shown if no link was added after command execution

### DIFF
--- a/src/linkui.js
+++ b/src/linkui.js
@@ -154,17 +154,17 @@ export default class LinkUI extends Plugin {
 		// Execute link command after clicking the "Save" button.
 		this.listenTo( formView, 'submit', () => {
 			editor.execute( 'link', formView.urlInputView.inputView.element.value );
-			this._removeFormView();
+			this._closeFormView();
 		} );
 
 		// Hide the panel after clicking the "Cancel" button.
 		this.listenTo( formView, 'cancel', () => {
-			this._removeFormView();
+			this._closeFormView();
 		} );
 
 		// Close the panel on esc key press when the **form has focus**.
 		formView.keystrokes.set( 'Esc', ( data, cancel ) => {
-			this._removeFormView();
+			this._closeFormView();
 			cancel();
 		} );
 
@@ -304,6 +304,22 @@ export default class LinkUI extends Plugin {
 		// https://github.com/ckeditor/ckeditor5-link/issues/78
 		// https://github.com/ckeditor/ckeditor5-link/issues/123
 		this.formView.urlInputView.inputView.element.value = linkCommand.value || '';
+	}
+
+	/**
+	 * Closes form view. Decides whether the balloon should be hidden completely or if action view should be shown. This is decided upon
+	 * link command value (which has value if the document selection is in link).
+	 *
+	 * @private
+	 */
+	_closeFormView() {
+		const linkCommand = this.editor.commands.get( 'link' );
+
+		if ( linkCommand.value !== undefined ) {
+			this._removeFormView();
+		} else {
+			this._hideUI();
+		}
 	}
 
 	/**

--- a/tests/linkui.js
+++ b/tests/linkui.js
@@ -812,15 +812,44 @@ describe( 'LinkUI', () => {
 				expect( focusEditableSpy.calledOnce ).to.be.true;
 			} );
 
-			it( 'should hide and reveal the #actionsView on formView#cancel event', () => {
+			it( 'should hide and reveal the #actionsView on formView#cancel event if link command has a value', () => {
 				linkUIFeature._showUI();
+
+				const command = editor.commands.get( 'link' );
+				command.value = 'http://foo.com';
+
 				formView.fire( 'cancel' );
 
 				expect( balloon.visibleView ).to.equal( actionsView );
 				expect( focusEditableSpy.calledOnce ).to.be.true;
 			} );
 
-			it( 'should hide after Esc key press', () => {
+			it( 'should hide the balloon on formView#cancel if link command does not have a value', () => {
+				linkUIFeature._showUI();
+				formView.fire( 'cancel' );
+
+				expect( balloon.visibleView ).to.be.null;
+			} );
+
+			it( 'should hide and reveal the #actionsView after Esc key press if link command has a value', () => {
+				const keyEvtData = {
+					keyCode: keyCodes.esc,
+					preventDefault: sinon.spy(),
+					stopPropagation: sinon.spy()
+				};
+
+				linkUIFeature._showUI();
+
+				const command = editor.commands.get( 'link' );
+				command.value = 'http://foo.com';
+
+				formView.keystrokes.press( keyEvtData );
+
+				expect( balloon.visibleView ).to.equal( actionsView );
+				expect( focusEditableSpy.calledOnce ).to.be.true;
+			} );
+
+			it( 'should hide the balloon after Esc key press if link command does not have a value', () => {
 				const keyEvtData = {
 					keyCode: keyCodes.esc,
 					preventDefault: sinon.spy(),
@@ -830,8 +859,8 @@ describe( 'LinkUI', () => {
 				linkUIFeature._showUI();
 
 				formView.keystrokes.press( keyEvtData );
-				expect( balloon.visibleView ).to.equal( actionsView );
-				expect( focusEditableSpy.calledOnce ).to.be.true;
+
+				expect( balloon.visibleView ).to.be.null;
 			} );
 
 			// https://github.com/ckeditor/ckeditor5/issues/1501


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Link balloon will not be shown if no link was added after command execution. Closes #171.