### PR TITLE
Add documentation for link decorators.

### DIFF
--- a/docs/_snippets/features/build-link-source.js
+++ b/docs/_snippets/features/build-link-source.js
@@ -1,0 +1,12 @@
+/**
+ * @license Copyright (c) 2003-2019, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+/* globals window */
+
+import ClassicEditor from '@ckeditor/ckeditor5-build-classic/src/ckeditor';
+import { CS_CONFIG } from '@ckeditor/ckeditor5-cloud-services/tests/_utils/cloud-services-config';
+
+window.ClassicEditor = ClassicEditor;
+window.CS_CONFIG = CS_CONFIG;

--- a/docs/_snippets/features/link.js
+++ b/docs/_snippets/features/link.js
@@ -3,10 +3,7 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
-/* globals console, window, document */
-
-import ClassicEditor from '@ckeditor/ckeditor5-build-classic/src/ckeditor';
-import { CS_CONFIG } from '@ckeditor/ckeditor5-cloud-services/tests/_utils/cloud-services-config';
+/* globals console, window, document, ClassicEditor, CS_CONFIG */
 
 ClassicEditor
 	.create( document.querySelector( '#snippet-link' ), {

--- a/docs/_snippets/features/linkdecorators.html
+++ b/docs/_snippets/features/linkdecorators.html
@@ -1,0 +1,14 @@
+<div id="snippet-link-decorators">
+	<h2>Links list</h2>
+	<ol>
+		<li>
+			<a href="https://ckeditor.com">Link to external page</a>
+		</li>
+		<li>
+			<a href="/">Link to internal page</a>
+		</li>
+	</ol>
+</div>
+<pre class="highlight">
+	<code class="html hljs" id="output-link-decorators"></code>
+</pre>

--- a/docs/_snippets/features/linkdecorators.html
+++ b/docs/_snippets/features/linkdecorators.html
@@ -1,14 +1,10 @@
 <div id="snippet-link-decorators">
-	<h2>Links list</h2>
-	<ol>
-		<li>
-			<a href="https://ckeditor.com">Link to external page</a>
-		</li>
-		<li>
-			<a href="/">Link to internal page</a>
-		</li>
-	</ol>
+	<p>
+		An <a href="https://ckeditor.com">external page</a> and a
+		<a download="download" href="/">downloadable resource</a>.
+	</p>
 </div>
+
 <pre class="highlight">
 	<code class="html hljs" id="output-link-decorators"></code>
 </pre>

--- a/docs/_snippets/features/linkdecorators.html
+++ b/docs/_snippets/features/linkdecorators.html
@@ -1,7 +1,7 @@
 <div id="snippet-link-decorators">
 	<p>
 		An <a href="https://ckeditor.com">external page</a> and a
-		<a download="download" href="/">downloadable resource</a>.
+		<a download="download" href="https://cdn.ckeditor.com/ckeditor5/12.2.0/classic/ckeditor.js">downloadable resource</a>.
 	</p>
 </div>
 

--- a/docs/_snippets/features/linkdecorators.js
+++ b/docs/_snippets/features/linkdecorators.js
@@ -3,10 +3,7 @@
  * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
  */
 
-/* globals console, window, document, Worker, setTimeout */
-
-import ClassicEditor from '@ckeditor/ckeditor5-build-classic/src/ckeditor';
-import { CS_CONFIG } from '@ckeditor/ckeditor5-cloud-services/tests/_utils/cloud-services-config';
+/* globals console, window, document, Worker, setTimeout, ClassicEditor, CS_CONFIG */
 
 ClassicEditor
 	.create( document.querySelector( '#snippet-link-decorators' ), {

--- a/docs/_snippets/features/linkdecorators.js
+++ b/docs/_snippets/features/linkdecorators.js
@@ -24,7 +24,7 @@ ClassicEditor
 			viewportTopOffset: window.getViewportTopOffsetConfig()
 		},
 		link: {
-			targetDecorator: true,
+			addTargetToExternalLinks: true,
 			decorators: [
 				{
 					mode: 'manual',

--- a/docs/features/link.md
+++ b/docs/features/link.md
@@ -27,7 +27,7 @@ CKEditor 5 allows for typing both at inner and outer boundaries of links to make
 
 ## Decorators
 
-Decorator feature provides an easy way to configure and extend links with additional attributes. A decorator is an object defined in the configuration, which describes additional rules applied to the link feature. There are 2 types of decorators: "automatic" and "manual". More information about each of them might be found in sections below or in {@link module:link/link~LinkConfig#decorators the API documentation}.
+Decorator feature provides easy in configuration way to extend links with additional HTML attributes. A decorator is an object defined in the editor's configuration, which describes additional rules of how and when those attributes should be added. There are 2 types of decorators: "automatic" and "manual". More information about each of them might be found in sections below or in {@link module:link/link~LinkConfig#decorators the API documentation}.
 
 <info-box warning>
 	**Warning:** It is not recommended to modify the same attribute through two or more decorators. All decorators work independent and its state is not reflected between them in any way. This also includes mixing manual and automatic decorators.
@@ -35,17 +35,17 @@ Decorator feature provides an easy way to configure and extend links with additi
 
 ### Demo
 
-In editor below is presented automatic and manual decorator feature. All external links gets automatically `target="_blank"` and `rel="noopener noreferrer"` attributes, what is done with {@link module:link/link~LinkConfig#targetDecorator} feature described below. The second decorator is a manual one, which adds a UI switch button with `"Downloadable"` label. Output data can be found in container below editor (its content updates automatically).
+In editor below is presented automatic and manual decorator feature. All external links gets automatically `target="_blank"` and `rel="noopener noreferrer"` attributes, what is done with {@link module:link/link~LinkConfig#addTargetToExternalLinks} feature described below. The second decorator is a manual one, which adds a UI switch button with `"Downloadable"` label. Output data can be found in the container below the editor (its content updates automatically).
 
 {@snippet features/linkdecorators}
 
 ### Automatic decorators
 
-This type of decorator is applied automatically based on the link's URL. The automatic decorator has defined a callback function in {@link module:link/link~LinkDecoratorAutomaticOption the configuration}, which decides whether given decorators should be executed or not. There might be multiple decorators configured for the same link, however, each of them should implement different attribute's set without overlaps.
+This type of decorator is applied automatically based on the link's URL. The automatic decorator has defined a callback function in {@link module:link/link~LinkDecoratorAutomaticDefinition the configuration}, which decides whether given decorators should be executed or not. There might be multiple decorators configured for the same link, however, each of them should implement a different set of attributes without overlaps.
 
-Automatic decorators are applied during {@link framework/guides/architecture/editing-engine#conversion downcasting data}, which means that result of working decorator is visible neither in the editor's model nor the UI in any way.
+Automatic decorators are applied during {@link framework/guides/architecture/editing-engine#conversion downcasting data}, which means that the result of working decorator is visible neither in the editor's model nor the UI in any way.
 
-For example, this decorator will add `download="download"` attribute to every link ending with `.pdf`:
+For example, this decorator will add `download="file.pdf"` attribute to every link ending with a `".pdf"` extension:
 ```js
 const config = {
 	link: {
@@ -54,7 +54,7 @@ const config = {
 				mode: 'automatic',
 				callback: url => url.endsWith( '.pdf' ),
 				attributes: {
-					download: 'download'
+					download: 'file.pdf'
 				}
 			}
 		]
@@ -62,11 +62,11 @@ const config = {
 }
 ```
 
-#### Target decorator
+#### "addTargetToExternalLinks" options
 
-Automatic decorators might be very handy in one particular situation. Mentioned case is to add `target="_blank"` and `rel="noopener noreferrer"` attributes to all external links in document. A request for this feature is quite common, and because of that, there is a {@link module:link/link~LinkConfig#targetDecorator configuration option}, which registers such automatic decorator. When `targetDecorator` option is set to `true`, then all links started with `http://`, `https://` or `//` are decorated with `target` and `rel` attributes, without need to implement own decorator.
+Automatic decorators might be very handy in one particular situation. The mentioned case is to add `target="_blank"` and `rel="noopener noreferrer"` attributes to all external links in the document. A request for this feature is quite common, and because of that, there is a {@link module:link/link~LinkConfig#addTargetToExternalLinks configuration option}, which registers such automatic decorator. When the `addTargetToExternalLinks` option is set to `true`, then all links started with `http://`, `https://` or `//` are decorated with `target` and `rel` attributes, without need to implement own decorator.
 
-Code of automatic decorator comes with `targetDecorator` option:
+Code of automatic decorator comes with `addTargetToExternalLinks` option:
 ```js
 {
 	mode: 'automatic',
@@ -79,24 +79,24 @@ Code of automatic decorator comes with `targetDecorator` option:
 ```
 
 <info-box>
-	If it is necessary to have a UI option, where the user decides, which links should be open in a new window, then `targetDecorator` options should remain `undefined` and there should be created a new **manual decorator** with proper configuration.
+	If it is necessary to have a UI option, where the user decides, which links should be open in a new window, then `addTargetToExternalLinks` options should remain `undefined` and there should be created a new **manual decorator** with proper configuration.
 </info-box>
 
 
 
 ### Manual decorators
 
-This type of decorator registers a UI element which can be switched by the user. Toggleable elements are located in editing view of the link. Modifying the state of this element and applying changes is reflected in the editor's model, what later is downcasted to attributes defined in {@link module:link/link~LinkDecoratorManualOption the manual decorator}.
+This type of decorator registers a UI element which can be switched by the user. Toggleable elements are located in editing view of the link. Modifying the state of this element and applying changes is reflected in the editor's model, what later is downcasted to attributes defined in {@link module:link/link~LinkDecoratorManualDefinition the manual decorator definition}.
 
-Configuration of manual decorator contains a label field used in a UI to describe given attributes set. It should be a compact and descriptive name for the user convenience.
+Configuration of manual decorator contains a label field used in a UI to describe given attributes set. It should be a compact and descriptive name for the user's convenience.
 
-For example, this decorator will add "Downloadable" switch button, which extends link with `download="download"` attribute when is turned on:
+For example, this decorator will add "Downloadable" switch button, which extends link with `download="file"` attribute when is turned on:
 ```js
 {
 	mode: 'manual',
 	label: 'Downloadable',
 	attributes: {
-		download: 'download'
+		download: 'file'
 	}
 }
 ```
@@ -141,7 +141,10 @@ The commands can be executed using the {@link module:core/editor/editor~Editor#e
 // When the selection is collapsed, it creates new text wrapped in a link.
 editor.execute( 'link', 'http://example.com' );
 
-// Removes the link from the selection.
+// If there are defined decorators then command can pass decorator's status as well:
+editor.execute( 'link', 'http://example.com', { linkIsExternal: true } );
+
+// Removes the link from the selection and all decorators if present.
 editor.execute( 'unlink' );
 ```
 

--- a/docs/features/link.md
+++ b/docs/features/link.md
@@ -23,20 +23,27 @@ CKEditor 5 allows for typing both at inner and outer boundaries of links to make
 
 {@img assets/img/typing-before.gif 770 The animation showing typing before the link in CKEditor 5 rich text editor.}
 
-## Link decorators
+## Decorators
 
-Link decorators is a feature that allows on extending HTML anchor with custom predefined attributes. There are 2 types of decorators: "automatic" and "manual". More information about each of them might be found in sections below. There might be applied multiple decorators to the same link (including manual and automatic decorators in one editor).
+Decorator feature provides an easy way to configure and extend links with additional attributes. A decorator is an object defined in the configuration, which describes additional rules applied to the link feature. There are 2 types of decorators: "automatic" and "manual". More information about each of them might be found in sections below or in {@link module:link/link~LinkConfig#decorators the API documentation}.
+
 <info-box warning>
-	**Warning:** It is not recommended to modify the same attribute through two or more decorators. All decorators works independent and its state is not reflected between them in any way. This also includes mixing manual and automatic decorators.
+	**Warning:** It is not recommended to modify the same attribute through two or more decorators. All decorators work independent and its state is not reflected between them in any way. This also includes mixing manual and automatic decorators.
 </info-box>
+
+### Demo
+
+In editor below is presented automatic and manual decorator feature. All external links gets automatically `target="_blank"` and `rel="noopener noreferrer"` attributes, what is done with {@link module:link/link~LinkConfig#targetDecorator} feature described below. The second decorator is a manual one, which adds a UI switch button with `"Downloadable"` label. Output data can be found in container below editor (its content updates automatically).
 
 {@snippet features/linkdecorators}
 
 ### Automatic decorators
 
-These types of decorators work during downcasting data ({@link framework/guides/architecture/editing-engine#conversion read more about conversion}). You can specify your own rules as a callback function. Function gets a link's href as an input argument and when the callback function returns `true`, then given attributes are applied for a processed link. There might be applied multiple rules for the same link, however you should never process the same attribute through different decorators. Rules how to define automatic decorators can be found in {@linkapi module:link/link~LinkDecoratorAutomaticOption automatic decorator definition}.
+This type of decorator is applied automatically based on the link's URL. The automatic decorator has defined a callback function in {@link module:link/link~LinkDecoratorAutomaticOption the configuration}, which decides whether given decorators should be executed or not. There might be multiple decorators configured for the same link, however, each of them should implement different attribute's set without overlaps.
 
-For example this decorator will add `download="download"` attribute to every link ending with `.pdf`:
+Automatic decorators are applied during {@link framework/guides/architecture/editing-engine#conversion downcasting data}, which means that result of working decorator is visible neither in the editor's model nor the UI in any way.
+
+For example, this decorator will add `download="download"` attribute to every link ending with `.pdf`:
 ```js
 const config = {
 	link: {
@@ -55,8 +62,9 @@ const config = {
 
 #### Target decorator
 
-There is also predefined configuration option {@linkapi module:link/link~LinkConfig#targetDecorator} which adds automatic decorator. This decorator adds two attributes ( `target="_blank"` and `rel="noopener noreferrer"` ) to all external links.
-Target decorator comes with followed configuration underneath:
+Automatic decorators might be very handy in one particular situation. Mentioned case is to add `target="_blank"` and `rel="noopener noreferrer"` attributes to all external links in document. A request for this feature is quite common, and because of that, there is a {@link module:link/link~LinkConfig#targetDecorator configuration option}, which registers such automatic decorator. When `targetDecorator` option is set to `true`, then all links started with `http://`, `https://` or `//` are decorated with `target` and `rel` attributes, without need to implement own decorator.
+
+Code of automatic decorator comes with `targetDecorator` option:
 ```js
 {
 	mode: 'automatic',
@@ -68,11 +76,19 @@ Target decorator comes with followed configuration underneath:
 }
 ```
 
+<info-box>
+	If it is necessary to have a UI option, where the user decides, which links should be open in a new window, then `targetDecorator` options should remain `undefined` and there should be created a new **manual decorator** with proper configuration.
+</info-box>
+
+
+
 ### Manual decorators
 
-These types of decorators adds switch button in user interface, which allows on toggling predefined attributes over a link. Switch buttons are visible in editing option of a link and requires applying changes to be set up over the link. Manual decorators doesn't have a callback property and are available for every link in editor. There is required `label` property, which is using as label for switch button in UI.
+This type of decorator registers a UI element which can be switched by the user. Toggleable elements are located in editing view of the link. Modifying the state of this element and applying changes is reflected in the editor's model, what later is downcasted to attributes defined in {@link module:link/link~LinkDecoratorManualOption the manual decorator}.
 
-For example this decorator will add "Downloadable" switch button:
+Configuration of manual decorator contains a label field used in a UI to describe given attributes set. It should be a compact and descriptive name for the user convenience.
+
+For example, this decorator will add "Downloadable" switch button, which extends link with `download="download"` attribute when is turned on:
 ```js
 {
 	mode: 'manual',

--- a/docs/features/link.md
+++ b/docs/features/link.md
@@ -23,6 +23,66 @@ CKEditor 5 allows for typing both at inner and outer boundaries of links to make
 
 {@img assets/img/typing-before.gif 770 The animation showing typing before the link in CKEditor 5 rich text editor.}
 
+## Link decorators
+
+Link decorators is a feature that allows on extending HTML anchor with custom predefined attributes. There are 2 types of decorators: "automatic" and "manual". More information about each of them might be found in sections below. There might be applied multiple decorators to the same link (including manual and automatic decorators in one editor).
+<info-box warning>
+	**Warning:** It is not recommended to modify the same attribute through two or more decorators. All decorators works independent and its state is not reflected between them in any way. This also includes mixing manual and automatic decorators.
+</info-box>
+
+{@snippet features/linkdecorators}
+
+### Automatic decorators
+
+These types of decorators work during downcasting data ({@link framework/guides/architecture/editing-engine#conversion read more about conversion}). You can specify your own rules as a callback function. Function gets a link's href as an input argument and when the callback function returns `true`, then given attributes are applied for a processed link. There might be applied multiple rules for the same link, however you should never process the same attribute through different decorators. Rules how to define automatic decorators can be found in {@linkapi module:link/link~LinkDecoratorAutomaticOption automatic decorator definition}.
+
+For example this decorator will add `download="download"` attribute to every link ending with `.pdf`:
+```js
+const config = {
+	link: {
+		decorators: [
+			{
+				mode: 'automatic',
+				callback: url => url.endsWith( '.pdf' ),
+				attributes: {
+					download: 'download'
+				}
+			}
+		]
+	}
+}
+```
+
+#### Target decorator
+
+There is also predefined configuration option {@linkapi module:link/link~LinkConfig#targetDecorator} which adds automatic decorator. This decorator adds two attributes ( `target="_blank"` and `rel="noopener noreferrer"` ) to all external links.
+Target decorator comes with followed configuration underneath:
+```js
+{
+	mode: 'automatic',
+	callback: url => /^(https?:)?\/\//.test( url ),
+	attributes: {
+		target: '_blank',
+		rel: 'noopener noreferrer'
+	}
+}
+```
+
+### Manual decorators
+
+These types of decorators adds switch button in user interface, which allows on toggling predefined attributes over a link. Switch buttons are visible in editing option of a link and requires applying changes to be set up over the link. Manual decorators doesn't have a callback property and are available for every link in editor. There is required `label` property, which is using as label for switch button in UI.
+
+For example this decorator will add "Downloadable" switch button:
+```js
+{
+	mode: 'manual',
+	label: 'Downloadable',
+	attributes: {
+		download: 'download'
+	}
+}
+```
+
 ## Installation
 
 <info-box info>

--- a/docs/features/link.md
+++ b/docs/features/link.md
@@ -3,6 +3,8 @@ title: Link
 category: features
 ---
 
+{@snippet features/build-link-source}
+
 The {@link module:link/link~Link} feature brings support for link editing to the editor. It allows for inserting hyperlinks into the edited content and offers the UI to create and edit them.
 
 ## Demo

--- a/src/link.js
+++ b/src/link.js
@@ -127,7 +127,7 @@ export default class Link extends Plugin {
  * {@link module:link/link~LinkConfig#addTargetToExternalLinks `config.link.addTargetToExternalLinks`}
  * configuration description to learn more.
  *
- * See also {@glink features/link#decorators} guide.
+ * See also {@glink features/link#decorators link's feature} guide for more information.
  *
  * @member {Object.<String, module:link/link~LinkDecoratorDefinition>} module:link/link~LinkConfig#decorators
  */
@@ -142,7 +142,7 @@ export default class Link extends Plugin {
 /**
  * The kind of the decorator. `'manual'` for all manual decorators and `'automatic'` for all automatic decorators.
  *
- * See also {@glink features/link#decorators} guide.
+ * See also {@glink features/link#decorators link's feature} guide for more information.
  *
  * @member {'manual'|'automatic'} module:link/link~LinkDecoratorDefinition#mode
  */

--- a/src/link.js
+++ b/src/link.js
@@ -61,6 +61,12 @@ export default class Link extends Plugin {
  * When set `true`, the `target="blank"` and `rel="noopener noreferrer"` attributes are automatically added to all external links
  * in the editor. By external are meant all links in the editor content starting with `http`, `https`, or `//`.
  *
+ *		const config = {
+ *			link: {
+ *				addTargetToExternalLinks: true
+ *			}
+ *		};
+ *
  * Internally, this option activates a predefined {@link module:link/link~LinkConfig#decorators automatic link decorator},
  * which extends all external links with the `target` and `rel` attributes without additional configuration.
  *
@@ -119,7 +125,7 @@ export default class Link extends Plugin {
  * and {@link module:link/link~LinkDecoratorManualDefinition manual} decorator option reference.
  *
  * **Warning:** Currently, link decorators work independently and no conflict resolution mechanism exists.
- * For example, configuring the `target` attribute using both an automatic and a manual decorator at a time could end up with a
+ * For example, configuring the `target` attribute using both an automatic and a manual decorator at a time could end up with
  * quirky results. The same applies if multiple manual or automatic decorators were defined for the same attribute.
  *
  * **Note**: Since the `target` attribute management for external links is a common use case, there is a predefined automatic decorator
@@ -127,22 +133,22 @@ export default class Link extends Plugin {
  * {@link module:link/link~LinkConfig#addTargetToExternalLinks `config.link.addTargetToExternalLinks`}
  * configuration description to learn more.
  *
- * See also {@glink features/link#decorators link's feature} guide for more information.
+ * See also {@glink features/link#custom-link-attributes-decorators link's feature} guide for more information.
  *
  * @member {Object.<String, module:link/link~LinkDecoratorDefinition>} module:link/link~LinkConfig#decorators
  */
 
 /**
- * Represents a link decorator definition {@link module:link/link~LinkDecoratorManualDefinition `'manual'`} or
- * {@link module:link/link~LinkDecoratorAutomaticDefinition `'automatic'`}.
+ * Represents a link decorator definition ({@link module:link/link~LinkDecoratorManualDefinition `'manual'`}
+ * or {@link module:link/link~LinkDecoratorAutomaticDefinition `'automatic'`}).
  *
  * @interface LinkDecoratorDefinition
  */
 
 /**
- * The kind of the decorator. `'manual'` for all manual decorators and `'automatic'` for all automatic decorators.
+ * The kind of the decorator.
  *
- * See also {@glink features/link#decorators link's feature} guide for more information.
+ * Check out the {@glink features/link#custom-link-attributes-decorators link feature} guide for more information.
  *
  * @member {'manual'|'automatic'} module:link/link~LinkDecoratorDefinition#mode
  */

--- a/src/link.js
+++ b/src/link.js
@@ -127,6 +127,8 @@ export default class Link extends Plugin {
  * {@link module:link/link~LinkConfig#addTargetToExternalLinks `config.link.addTargetToExternalLinks`}
  * configuration description to learn more.
  *
+ * See also {@glink features/link#decorators} guide.
+ *
  * @member {Object.<String, module:link/link~LinkDecoratorDefinition>} module:link/link~LinkConfig#decorators
  */
 
@@ -139,6 +141,8 @@ export default class Link extends Plugin {
 
 /**
  * The kind of the decorator. `'manual'` for all manual decorators and `'automatic'` for all automatic decorators.
+ *
+ * See also {@glink features/link#decorators} guide.
  *
  * @member {'manual'|'automatic'} module:link/link~LinkDecoratorDefinition#mode
  */


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Docs: Documentation for link's decorators. Closes #229.

---

### Additional information

~⚠️ branch target to `t/186` to have available feature to build snippets.~