### PR TITLE
Provide missing upcast converter for link decorators

### DIFF
--- a/src/linkediting.js
+++ b/src/linkediting.js
@@ -156,14 +156,10 @@ export default class LinkEditing extends Plugin {
 				model: decorator.id,
 				view: ( manualDecoratorName, writer ) => {
 					if ( manualDecoratorName ) {
-						const element = writer.createAttributeElement(
-							'a',
-							manualDecorators.get( decorator.id ).attributes,
-							{
-								priority: 5
-							}
-						);
+						const attributes = manualDecorators.get( decorator.id ).attributes;
+						const element = writer.createAttributeElement( 'a', attributes, { priority: 5 } );
 						writer.setCustomProperty( 'link', true, element );
+
 						return element;
 					}
 				} } );

--- a/src/linkediting.js
+++ b/src/linkediting.js
@@ -167,6 +167,17 @@ export default class LinkEditing extends Plugin {
 						return element;
 					}
 				} } );
+
+			editor.conversion.for( 'upcast' ).elementToAttribute( {
+				view: {
+					name: 'a',
+					attributes: manualDecorators.get( decorator.id ).attributes
+				},
+				model: {
+					key: decorator.id,
+					value: true
+				}
+			} );
 		} );
 	}
 

--- a/src/linkediting.js
+++ b/src/linkediting.js
@@ -170,8 +170,7 @@ export default class LinkEditing extends Plugin {
 					attributes: manualDecorators.get( decorator.id ).attributes
 				},
 				model: {
-					key: decorator.id,
-					value: true
+					key: decorator.id
 				}
 			} );
 		} );

--- a/tests/linkediting.js
+++ b/tests/linkediting.js
@@ -589,7 +589,7 @@ describe( 'LinkEditing', () => {
 		} );
 
 		describe( 'upcast converter', () => {
-			it( 'attributes from initial data are upcast to model', done => {
+			it( 'should upcast attributes from initial data', done => {
 				VirtualTestEditor
 					.create( {
 						initialData: '<p><a href="url" target="_blank" rel="noopener noreferrer" download="file">Foo</a>' +
@@ -630,7 +630,7 @@ describe( 'LinkEditing', () => {
 					.catch( done );
 			} );
 
-			it( 'partial and incorrect attributes are not upcast to the model', done => {
+			it( 'should not upcast partial and incorrect attributes', done => {
 				VirtualTestEditor
 					.create( {
 						initialData: '<p><a href="url" target="_blank" download="something">Foo</a>' +

--- a/tests/linkediting.js
+++ b/tests/linkediting.js
@@ -587,5 +587,89 @@ describe( 'LinkEditing', () => {
 				expect( editor.getData() ).to.equal( '<p><a href="http://example.com">foo</a>bar</p>' );
 			} );
 		} );
+
+		describe( 'upcast converter', () => {
+			it( 'attributes from initial data are upcast to model', done => {
+				VirtualTestEditor
+					.create( {
+						initialData: '<p><a href="url" target="_blank" rel="noopener noreferrer" download="file">Foo</a>' +
+							'<a href="example.com" download="file">Bar</a></p>',
+						plugins: [ Paragraph, LinkEditing, Enter ],
+						link: {
+							decorators: {
+								isExternal: {
+									mode: 'manual',
+									label: 'Open in a new window',
+									attributes: {
+										target: '_blank',
+										rel: 'noopener noreferrer'
+									}
+								},
+								isDownloadable: {
+									mode: 'manual',
+									label: 'Downloadable',
+									attributes: {
+										download: 'file'
+									}
+								}
+							}
+						}
+					} )
+					.then( newEditor => {
+						editor = newEditor;
+						model = editor.model;
+
+						expect( getModelData( model, { withoutSelection: true } ) ).to.equal(
+							'<paragraph>' +
+								'<$text linkHref="url" linkIsDownloadable="true" linkIsExternal="true">Foo</$text>' +
+								'<$text linkHref="example.com" linkIsDownloadable="true">Bar</$text>' +
+							'</paragraph>'
+						);
+					} )
+					.then( done )
+					.catch( done );
+			} );
+
+			it( 'partial and incorrect attributes are not upcast to the model', done => {
+				VirtualTestEditor
+					.create( {
+						initialData: '<p><a href="url" target="_blank" download="something">Foo</a>' +
+							'<a href="example.com" download="test">Bar</a></p>',
+						plugins: [ Paragraph, LinkEditing, Enter ],
+						link: {
+							decorators: {
+								isExternal: {
+									mode: 'manual',
+									label: 'Open in a new window',
+									attributes: {
+										target: '_blank',
+										rel: 'noopener noreferrer'
+									}
+								},
+								isDownloadable: {
+									mode: 'manual',
+									label: 'Downloadable',
+									attributes: {
+										download: 'file'
+									}
+								}
+							}
+						}
+					} )
+					.then( newEditor => {
+						editor = newEditor;
+						model = editor.model;
+
+						expect( getModelData( model, { withoutSelection: true } ) ).to.equal(
+							'<paragraph>' +
+								'<$text linkHref="url">Foo</$text>' +
+								'<$text linkHref="example.com">Bar</$text>' +
+							'</paragraph>'
+						);
+					} )
+					.then( done )
+					.catch( done );
+			} );
+		} );
 	} );
 } );

--- a/tests/manual/linkdecorator.html
+++ b/tests/manual/linkdecorator.html
@@ -1,11 +1,11 @@
 <h2>Manual decorators</h2>
 <div id="editor">
-	<p>This is <a href="http://ckeditor.com">CKEditor5</a> from <a href="http://cksource.com">CKSource</a>.</p>
-	<p>This is <a href="//ckeditor.com">CKEditor5</a> as schemaless url.</p>
+	<p>This is <a href="http://ckeditor.com" target="_blank" rel="noopener noreferrer">CKEditor5</a> from <a href="http://cksource.com" download="download" target="_blank" rel="noopener noreferrer" >CKSource</a>.</p>
+	<p>This is <a href="//ckeditor.com" class="gallery">CKEditor5</a> as schemaless url.</p>
 	<p>This is <a href="#anchor">anchor</a> on this page.</p>
-	<p>This is some random <a href="ftp://127.0.0.1">ftp address</a>.</p>
+	<p>This is some random <a href="ftp://127.0.0.1" download="download">ftp address</a>.</p>
 	<p>This is some <a href="mailto:random@user.org">mail</a>.</p>
-	<p>This is some <a href="tel:123456789">phone number</a>.</p>
+	<p>This is some <a href="tel:123456789">phone number</a> with gallery decorator</p>
 </div>
 
 <h2>Automatic decorators</h2>

--- a/tests/manual/linkdecorator.html
+++ b/tests/manual/linkdecorator.html
@@ -10,7 +10,7 @@
 
 <h2>Automatic decorators</h2>
 <div id="editor2">
-	<p>This is <a href="http://ckeditor.com">CKEditor5</a> from <a href="http://cksource.com">CKSource</a>.</p>
+	<p>This is <a href="http://ckeditor.com" target="_blank" rel="noopener noreferrer" download="download">CKEditor5</a> from <a href="http://cksource.com">CKSource</a>.</p>
 	<p>This is <a href="//ckeditor.com">CKEditor5</a> as schemaless url.</p>
 	<p>This is <a href="#anchor">anchor</a> on this page.</p>
 	<p>This is some random <a href="ftp://127.0.0.1">ftp address</a>.</p>

--- a/tests/manual/linkdecorator.js
+++ b/tests/manual/linkdecorator.js
@@ -3,7 +3,7 @@
  * For licensing, see LICENSE.md.
  */
 
-/* globals console:false, window, document */
+/* globals console:false, window, document, CKEditorInspector */
 
 import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor';
 import Enter from '@ckeditor/ckeditor5-enter/src/enter';
@@ -15,6 +15,8 @@ import Clipboard from '@ckeditor/ckeditor5-clipboard/src/clipboard';
 
 // Just to have nicely styles switchbutton;
 import '@ckeditor/ckeditor5-theme-lark/theme/ckeditor5-ui/components/list/list.css';
+
+window.editors = {};
 
 ClassicEditor
 	.create( document.querySelector( '#editor' ), {
@@ -48,10 +50,7 @@ ClassicEditor
 		}
 	} )
 	.then( editor => {
-		if ( !window.editors ) {
-			window.editors = {};
-		}
-		window.editor = editor;
+		CKEditorInspector.attach( 'manual', editor );
 		window.editors.manualDecorators = editor;
 	} )
 	.catch( err => {
@@ -83,9 +82,7 @@ ClassicEditor
 		}
 	} )
 	.then( editor => {
-		if ( !window.editors ) {
-			window.editors = {};
-		}
+		CKEditorInspector.attach( 'automatic', editor );
 		window.editors.automaticDecorators = editor;
 	} )
 	.catch( err => {

--- a/tests/manual/linkdecorator.md
+++ b/tests/manual/linkdecorator.md
@@ -4,12 +4,17 @@
 
 1. Should be available for every link.
 2. Should be applied to the content only when "Save" was clicked.
-3. There should be 3 manual decorators available:
+3. There should be initially set some decorators over specific links based on source data of the editor:
+  * `CKEditor5` has: "Open in a new window"
+  * `CKSource` has: "Open in a new window" and "Downloadable"
+  * `CKEditor5` (schemaless) has: "Gallery"
+  * `ftp address` has: "Downloadable"
+4. There should be 3 manual decorators available:
   * Open in new a new tab
   * Downloadable
   * Gallery link
-4. State of the decorator switches should reflect the model of the currently selected link.
-5. Switch buttons should be focusable (with the tab key), after the URL input. The "save" and "cancel" buttons should be focused last.
+5. State of the decorator switches should reflect the model of the currently selected link.
+6. Switch buttons should be focusable (with the tab key), after the URL input. The "save" and "cancel" buttons should be focused last.
 
 ### Automatic decorators (window.editors.automaticDecorators).
 

--- a/tests/manual/linkdecorator.md
+++ b/tests/manual/linkdecorator.md
@@ -5,14 +5,14 @@
 1. Should be available for every link.
 2. Should be applied to the content only when "Save" was clicked.
 3. There should be initially set some decorators over specific links based on source data of the editor:
-  * `CKEditor5` has: "Open in a new window"
-  * `CKSource` has: "Open in a new window" and "Downloadable"
-  * `CKEditor5` (schemaless) has: "Gallery"
-  * `ftp address` has: "Downloadable"
+    * `CKEditor5` has: "Open in a new tab"
+    * `CKSource` has: "Open in a new tab" and "Downloadable"
+    * `CKEditor5` (schemaless) has: "Gallery"
+    * `ftp address` has: "Downloadable"
 4. There should be 3 manual decorators available:
-  * Open in new a new tab
-  * Downloadable
-  * Gallery link
+    * Open in new a new tab
+    * Downloadable
+    * Gallery link
 5. State of the decorator switches should reflect the model of the currently selected link.
 6. Switch buttons should be focusable (with the tab key), after the URL input. The "save" and "cancel" buttons should be focused last.
 
@@ -22,5 +22,5 @@
 2. There should be no changes to the model or the view of the editors.
 3. Decorator data should be added during downcast (run `window.editors.automaticDecorators.getData()` to see how it works).
 4. There are 2 additional decorators in this editor:
-  * phone, which detects all links starting with `tel:` and adds the `phone` CSS class to such link,
-  * internal, which adds the `internal` CSS class to all links starting with `#`.
+    * phone, which detects all links starting with `tel:` and adds the `phone` CSS class to such link,
+    * internal, which adds the `internal` CSS class to all links starting with `#`.


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Provide missing upcast converter for link decorators. Closes #233.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
