### PR TITLE
Improved balloon positioning when there is more than one stack in the rotator

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "lodash-es": "^4.17.10"
   },
   "devDependencies": {
+    "@ckeditor/ckeditor5-block-quote": "^11.1.2",
     "@ckeditor/ckeditor5-clipboard": "^12.0.1",
     "@ckeditor/ckeditor5-editor-classic": "^12.1.3",
     "@ckeditor/ckeditor5-enter": "^11.0.4",


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Improved balloon positioning when there is more than one stack in the rotator. Closes #242.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
