### PR TITLE
t/ckeditor5/1151: Passed editor content direction to the bindTwoStepCaretToAttribute() helper in the LinkEditing plugin

### DIFF
--- a/src/linkediting.js
+++ b/src/linkediting.js
@@ -89,7 +89,7 @@ export default class LinkEditing extends Plugin {
 			model: editor.model,
 			emitter: this,
 			attribute: 'linkHref',
-			contentDirection: locale.contentLanguageDirection
+			locale
 		} );
 
 		// Setup highlight over selected link.

--- a/src/linkediting.js
+++ b/src/linkediting.js
@@ -84,7 +84,13 @@ export default class LinkEditing extends Plugin {
 		this._enableManualDecorators( linkDecorators.filter( item => item.mode === DECORATOR_MANUAL ) );
 
 		// Enable two-step caret movement for `linkHref` attribute.
-		bindTwoStepCaretToAttribute( editor.editing.view, editor.model, this, 'linkHref', locale.contentLanguageDirection );
+		bindTwoStepCaretToAttribute( {
+			view: editor.editing.view,
+			model: editor.model,
+			emitter: this,
+			attribute: 'linkHref',
+			contentDirection: locale.contentLanguageDirection
+		} );
 
 		// Setup highlight over selected link.
 		this._setupLinkHighlight();

--- a/src/linkediting.js
+++ b/src/linkediting.js
@@ -47,6 +47,7 @@ export default class LinkEditing extends Plugin {
 	 */
 	init() {
 		const editor = this.editor;
+		const locale = editor.locale;
 
 		// Allow link attribute on all inline nodes.
 		editor.model.schema.extend( '$text', { allowAttributes: 'linkHref' } );
@@ -83,7 +84,7 @@ export default class LinkEditing extends Plugin {
 		this._enableManualDecorators( linkDecorators.filter( item => item.mode === DECORATOR_MANUAL ) );
 
 		// Enable two-step caret movement for `linkHref` attribute.
-		bindTwoStepCaretToAttribute( editor.editing.view, editor.model, this, 'linkHref' );
+		bindTwoStepCaretToAttribute( editor.editing.view, editor.model, this, 'linkHref', locale.contentLanguageDirection );
 
 		// Setup highlight over selected link.
 		this._setupLinkHighlight();

--- a/tests/linkediting.js
+++ b/tests/linkediting.js
@@ -72,7 +72,9 @@ describe( 'LinkEditing', () => {
 			return VirtualTestEditor
 				.create( {
 					plugins: [ Paragraph, LinkEditing, Enter ],
-					contentLanguage: 'ar'
+					language: {
+						content: 'ar'
+					}
 				} )
 				.then( editor => {
 					model = editor.model;

--- a/tests/linkediting.js
+++ b/tests/linkediting.js
@@ -48,24 +48,54 @@ describe( 'LinkEditing', () => {
 		expect( model.schema.checkAttribute( [ '$block' ], 'linkHref' ) ).to.be.false;
 	} );
 
-	it( 'should bind two-step caret movement to `linkHref` attribute', () => {
-		// Let's check only the minimum to not duplicated `bindTwoStepCaretToAttribute()` tests.
-		// Testing minimum is better then testing using spies that might give false positive results.
+	// Let's check only the minimum to not duplicate `bindTwoStepCaretToAttribute()` tests.
+	// Testing minimum is better than testing using spies that might give false positive results.
+	describe( 'two-step caret movement', () => {
+		it( 'should be bound to th `linkHref` attribute (LTR)', () => {
+			// Put selection before the link element.
+			setModelData( editor.model, '<paragraph>foo[]<$text linkHref="url">b</$text>ar</paragraph>' );
 
-		// Put selection before the link element.
-		setModelData( editor.model, '<paragraph>foo[]<$text linkHref="url">b</$text>ar</paragraph>' );
+			// The selection's gravity is not overridden because selection landed here not because of `keydown`.
+			expect( editor.model.document.selection.isGravityOverridden ).to.false;
 
-		// The selection's gravity is not overridden because selection land here not as a result of `keydown`.
-		expect( editor.model.document.selection.isGravityOverridden ).to.false;
+			// So let's simulate the `keydown` event.
+			editor.editing.view.document.fire( 'keydown', {
+				keyCode: keyCodes.arrowright,
+				preventDefault: () => {},
+				domTarget: document.body
+			} );
 
-		// So let's simulate `keydown` event.
-		editor.editing.view.document.fire( 'keydown', {
-			keyCode: keyCodes.arrowright,
-			preventDefault: () => {},
-			domTarget: document.body
+			expect( editor.model.document.selection.isGravityOverridden ).to.true;
 		} );
 
-		expect( editor.model.document.selection.isGravityOverridden ).to.true;
+		it( 'should be bound to th `linkHref` attribute (RTL)', () => {
+			return VirtualTestEditor
+				.create( {
+					plugins: [ Paragraph, LinkEditing, Enter ],
+					contentLanguage: 'ar'
+				} )
+				.then( editor => {
+					model = editor.model;
+					view = editor.editing.view;
+
+					// Put selection before the link element.
+					setModelData( editor.model, '<paragraph>foo[]<$text linkHref="url">b</$text>ar</paragraph>' );
+
+					// The selection's gravity is not overridden because selection landed here not because of `keydown`.
+					expect( editor.model.document.selection.isGravityOverridden ).to.false;
+
+					// So let's simulate the `keydown` event.
+					editor.editing.view.document.fire( 'keydown', {
+						keyCode: keyCodes.arrowleft,
+						preventDefault: () => {},
+						domTarget: document.body
+					} );
+
+					expect( editor.model.document.selection.isGravityOverridden ).to.true;
+
+					return editor.destroy();
+				} );
+		} );
 	} );
 
 	describe( 'command', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Passed editor content direction to the `bindTwoStepCaretToAttribute()` helper in the `LinkEditing` plugin. See ckeditor/ckeditor5#1151.

---

### Additional information

A piece of https://github.com/ckeditor/ckeditor5/pull/1881.