### PR TITLE
Add missing return value for link postfixer

### DIFF
--- a/src/linkediting.js
+++ b/src/linkediting.js
@@ -198,6 +198,7 @@ export default class LinkEditing extends Plugin {
 		// Adding the class.
 		view.document.registerPostFixer( writer => {
 			const selection = editor.model.document.selection;
+			let changed = false;
 
 			if ( selection.hasAttribute( 'linkHref' ) ) {
 				const modelRange = findLinkRange( selection.getFirstPosition(), selection.getAttribute( 'linkHref' ), editor.model );
@@ -206,12 +207,15 @@ export default class LinkEditing extends Plugin {
 				// There might be multiple `a` elements in the `viewRange`, for example, when the `a` element is
 				// broken by a UIElement.
 				for ( const item of viewRange.getItems() ) {
-					if ( item.is( 'a' ) ) {
+					if ( item.is( 'a' ) && !item.hasClass( HIGHLIGHT_CLASS ) ) {
 						writer.addClass( HIGHLIGHT_CLASS, item );
 						highlightedLinks.add( item );
+						changed = true;
 					}
 				}
 			}
+
+			return changed;
 		} );
 
 		// Removing the class.


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Add missing return value for link postfixer. Closes #241.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
