### PR TITLE
Set UI buttons as toggleable

### DIFF
--- a/src/linkui.js
+++ b/src/linkui.js
@@ -204,7 +204,8 @@ export default class LinkUI extends Plugin {
 			button.isToggleable = true;
 
 			// Bind button to the command.
-			button.bind( 'isOn', 'isEnabled' ).to( linkCommand, 'value', 'isEnabled' );
+			button.bind( 'isEnabled' ).to( linkCommand, 'isEnabled' );
+			button.bind( 'isOn' ).to( linkCommand, 'value', value => !!value );
 
 			// Show the panel on button click.
 			this.listenTo( button, 'execute', () => this._showUI( true ) );

--- a/src/linkui.js
+++ b/src/linkui.js
@@ -201,6 +201,7 @@ export default class LinkUI extends Plugin {
 			button.icon = linkIcon;
 			button.keystroke = linkKeystroke;
 			button.tooltip = true;
+			button.isToggleable = true;
 
 			// Bind button to the command.
 			button.bind( 'isOn', 'isEnabled' ).to( linkCommand, 'value', 'isEnabled' );

--- a/tests/linkui.js
+++ b/tests/linkui.js
@@ -85,6 +85,10 @@ describe( 'LinkUI', () => {
 				expect( linkButton ).to.be.instanceOf( ButtonView );
 			} );
 
+			it( 'should be toggleable button', () => {
+				expect( linkButton.isToggleable ).to.be.true;
+			} );
+
 			it( 'should be bound to the link command', () => {
 				const command = editor.commands.get( 'link' );
 

--- a/tests/linkui.js
+++ b/tests/linkui.js
@@ -93,13 +93,13 @@ describe( 'LinkUI', () => {
 				const command = editor.commands.get( 'link' );
 
 				command.isEnabled = true;
-				command.value = true;
+				command.value = 'http://ckeditor.com';
 
 				expect( linkButton.isOn ).to.be.true;
 				expect( linkButton.isEnabled ).to.be.true;
 
 				command.isEnabled = false;
-				command.value = false;
+				command.value = undefined;
 
 				expect( linkButton.isOn ).to.be.false;
 				expect( linkButton.isEnabled ).to.be.false;


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Set UI buttons as toggleable.

---

### Additional information

Requires: ckeditor/ckeditor5-ui#517

* There is also change in `isOn` property to have sure that boolean value is kept inside it.
