### PR TITLE
i/5746: Link preview in the balloon should have `rel="noopener noreferrer"`

### DIFF
--- a/src/ui/linkactionsview.js
+++ b/src/ui/linkactionsview.js
@@ -209,7 +209,8 @@ export default class LinkActionsView extends View {
 					'ck-link-actions__preview'
 				],
 				href: bind.to( 'href', href => href && ensureSafeUrl( href ) ),
-				target: '_blank'
+				target: '_blank',
+				rel: 'noopener noreferrer'
 			}
 		} );
 

--- a/tests/ui/linkactionsview.js
+++ b/tests/ui/linkactionsview.js
@@ -84,8 +84,12 @@ describe( 'LinkActionsView', () => {
 				expect( view.previewButtonView.element.classList.contains( 'ck-link-actions__preview' ) ).to.be.true;
 			} );
 
-			it( 'has a target attribute', () => {
+			it( 'has a "target" attribute', () => {
 				expect( view.previewButtonView.element.getAttribute( 'target' ) ).to.equal( '_blank' );
+			} );
+
+			it( 'has a "rel" attribute', () => {
+				expect( view.previewButtonView.element.getAttribute( 'rel' ) ).to.equal( 'noopener noreferrer' );
 			} );
 
 			describe( '<a> bindings', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Link preview in the balloon should have `rel="noopener noreferrer"` set for security reasons. Closes ckeditor/ckeditor5#5746.
