### PR TITLE
Docs: Fix addTargetToLinks typo

### DIFF
--- a/docs/features/link.md
+++ b/docs/features/link.md
@@ -132,7 +132,7 @@ ClassicEditor
 		// ...
 		link: {
 			decorators: {
-				addTargetToLinks: {
+				addTargetToExternalLinks: {
 					mode: 'manual',
 					label: 'Open in a new tab',
 					attributes: {


### PR DESCRIPTION
Fix typo with external links snippet. (`addTargetToLinks` to `addTargetToExternalLinks`)