### PR TITLE
i/353: Focus the editor before executing a command

### DIFF
--- a/src/linkui.js
+++ b/src/linkui.js
@@ -208,7 +208,10 @@ export default class LinkUI extends Plugin {
 			button.bind( 'isOn' ).to( linkCommand, 'value', value => !!value );
 
 			// Show the panel on button click.
-			this.listenTo( button, 'execute', () => this._showUI( true ) );
+			this.listenTo( button, 'execute', () => {
+				this._showUI( true );
+				editor.editing.view.focus();
+			} );
 
 			return button;
 		} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Focus the editor before executing toolbar buttons' command. Closes ckeditor/ckeditor5#353.
