### PR TITLE
Toolbar will be displayed even if the command is disabled

### DIFF
--- a/src/linkui.js
+++ b/src/linkui.js
@@ -188,9 +188,7 @@ export default class LinkUI extends Plugin {
 			// Prevent focusing the search bar in FF and opening new tab in Edge. #153, #154.
 			cancel();
 
-			if ( linkCommand.isEnabled ) {
-				this._showUI( true );
-			}
+			this._showUI( true );
 		} );
 
 		editor.ui.componentFactory.add( 'link', locale => {
@@ -355,20 +353,12 @@ export default class LinkUI extends Plugin {
 	}
 
 	/**
-	 * Shows the correct UI type for the current state of the command. It is either
-	 * {@link #formView} or {@link #actionsView}.
+	 * Shows the correct UI type. It is either {@link #formView} or {@link #actionsView}.
 	 *
 	 * @param {Boolean} forceVisible
 	 * @private
 	 */
 	_showUI( forceVisible = false ) {
-		const editor = this.editor;
-		const linkCommand = editor.commands.get( 'link' );
-
-		if ( !linkCommand.isEnabled ) {
-			return;
-		}
-
 		// When there's no link under the selection, go straight to the editing UI.
 		if ( !this._getSelectedLinkElement() ) {
 			this._addActionsView();

--- a/tests/linkui.js
+++ b/tests/linkui.js
@@ -122,15 +122,6 @@ describe( 'LinkUI', () => {
 			editor.editing.view.document.isFocused = true;
 		} );
 
-		it( 'should not work if the link command is disabled', () => {
-			setModelData( editor.model, '<paragraph>f[o]o</paragraph>' );
-			editor.commands.get( 'link' ).isEnabled = false;
-
-			linkUIFeature._showUI();
-
-			expect( balloon.visibleView ).to.be.null;
-		} );
-
 		it( 'should not throw if the UI is already visible', () => {
 			setModelData( editor.model, '<paragraph>f[o]o</paragraph>' );
 
@@ -532,19 +523,6 @@ describe( 'LinkUI', () => {
 	describe( 'keyboard support', () => {
 		it( 'should show the UI on Ctrl+K keystroke', () => {
 			const spy = testUtils.sinon.stub( linkUIFeature, '_showUI' ).returns( {} );
-			const command = editor.commands.get( 'link' );
-
-			command.isEnabled = false;
-
-			editor.keystrokes.press( {
-				keyCode: keyCodes.k,
-				ctrlKey: true,
-				preventDefault: sinon.spy(),
-				stopPropagation: sinon.spy()
-			} );
-			sinon.assert.notCalled( spy );
-
-			command.isEnabled = true;
 
 			editor.keystrokes.press( {
 				keyCode: keyCodes.k,


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: The balloon toolbar will be displayed if a selection is placed inside a link even if the `link` command is disabled. Closes ckeditor/ckeditor5#4834.
