### PR TITLE
i/6530: Get value of the URL from DOM element.value

### DIFF
--- a/src/linkui.js
+++ b/src/linkui.js
@@ -154,7 +154,7 @@ export default class LinkUI extends Plugin {
 
 		// Execute link command after clicking the "Save" button.
 		this.listenTo( formView, 'submit', () => {
-			editor.execute( 'link', formView.urlInputView.fieldView.value, formView.getDecoratorSwitchesState() );
+			editor.execute( 'link', formView.urlInputView.fieldView.element.value, formView.getDecoratorSwitchesState() );
 			this._closeFormView();
 		} );
 
@@ -307,7 +307,7 @@ export default class LinkUI extends Plugin {
 		// clicked the same link), they would see the old value instead of the actual value of the command.
 		// https://github.com/ckeditor/ckeditor5-link/issues/78
 		// https://github.com/ckeditor/ckeditor5-link/issues/123
-		this.formView.urlInputView.fieldView.value = linkCommand.value || '';
+		this.formView.urlInputView.fieldView.element.value = linkCommand.value || '';
 	}
 
 	/**

--- a/tests/linkui.js
+++ b/tests/linkui.js
@@ -236,12 +236,12 @@ describe( 'LinkUI', () => {
 			setModelData( editor.model, '<paragraph><$text linkHref="url">f[]oo</$text></paragraph>' );
 
 			// Mock some leftover value **in DOM**, e.g. after previous editing.
-			formView.urlInputView.fieldView.value = 'leftover';
+			formView.urlInputView.fieldView.element.value = 'leftover';
 
 			linkUIFeature._showUI();
 			actionsView.fire( 'edit' );
 
-			expect( formView.urlInputView.fieldView.value ).to.equal( 'url' );
+			expect( formView.urlInputView.fieldView.element.value ).to.equal( 'url' );
 		} );
 
 		// https://github.com/ckeditor/ckeditor5-link/issues/123
@@ -249,7 +249,7 @@ describe( 'LinkUI', () => {
 			setModelData( editor.model, '<paragraph>f[]oo</paragraph>' );
 
 			linkUIFeature._showUI();
-			expect( formView.urlInputView.fieldView.value ).to.equal( '' );
+			expect( formView.urlInputView.fieldView.element.value ).to.equal( '' );
 		} );
 
 		it( 'should optionally force `main` stack to be visible', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Get the value of URL from the DOM input element value, instead of the `LinkFormView#urlInputView#fieldView#value` on submit. Closes ckeditor/ckeditor5#6530.

