### PR TITLE
i/6053: The gravity of the selection should be overridden if a link was pasted for better typing experience

### DIFF
--- a/src/linkediting.js
+++ b/src/linkediting.js
@@ -275,6 +275,7 @@ export default class LinkEditing extends Plugin {
 
 		viewDocument.on( 'paste', () => {
 			const nodeBefore = selection.anchor.nodeBefore;
+			const nodeAfter = selection.anchor.nodeAfter;
 
 			// NOTE: ↰ and ↱ represent the gravity of the selection.
 
@@ -318,6 +319,24 @@ export default class LinkEditing extends Plugin {
 			//		<$text bold="true">PASTED</$text>[]<$text linkHref="foo">link</$text>
 			//
 			if ( !nodeBefore.hasAttribute( 'linkHref' ) ) {
+				return;
+			}
+
+			// Filter out the following case where a link is a pasted in the middle (or before) another link
+			// (different URLs, so they will not merge). In this (let's say weird) case, we can leave the gravity
+			// as it is because it would stick to the first link anyway.
+			//
+			// Before paste:
+			//
+			//		                       ↰
+			//		<$text linkHref="foo">l[]ink</$text>
+			//
+			// Expected after paste:
+			//
+			//		                                                           ↰
+			//		<$text linkHref="foo">l</$text><$text linkHref="bar">PASTED[]</$text><$text linkHref="foo">ink</$text>
+			//
+			if ( nodeAfter && nodeAfter.hasAttribute( 'linkHref' ) ) {
 				return;
 			}
 

--- a/tests/linkediting.js
+++ b/tests/linkediting.js
@@ -135,6 +135,27 @@ describe( 'LinkEditing', () => {
 			expect( model.document.selection.isGravityOverridden ).to.be.true;
 		} );
 
+		it( 'should not override the gravity when pasting a non-link content', () => {
+			const dataTransferMock = createDataTransfer( { 'text/html': '<b>PASTED</b>' } );
+
+			setModelData( model, '<paragraph><$text linkHref="ckeditor.com">foo[]</$text></paragraph>' );
+
+			view.document.fire( 'paste', {
+				dataTransfer: dataTransferMock,
+				preventDefault() {},
+				stopPropagation() {}
+			} );
+
+			expect( getModelData( model ) ).to.equal(
+				'<paragraph>' +
+					'<$text linkHref="ckeditor.com">foo</$text>' +
+					'<$text bold="true">PASTED[]</$text>' +
+				'</paragraph>'
+			);
+
+			expect( model.document.selection.isGravityOverridden ).to.be.false;
+		} );
+
 		it( 'should not override the gravity when pasting in the middle of a link with the same URL', () => {
 			const dataTransferMock = createDataTransfer( { 'text/html': '<a href="ckeditor.com">PASTED</a>' } );
 

--- a/tests/linkediting.js
+++ b/tests/linkediting.js
@@ -180,6 +180,51 @@ describe( 'LinkEditing', () => {
 			expect( model.document.selection.isGravityOverridden ).to.be.true;
 		} );
 
+		it( 'should not override the gravity when pasting a link into another link (different URLs, they won\'t merge)', () => {
+			const dataTransferMock = createDataTransfer( { 'text/html': '<a href="http://PASTED">PASTED</a>' } );
+
+			setModelData( model, '<paragraph><$text linkHref="ckeditor.com">f[]oo</$text></paragraph>' );
+
+			view.document.fire( 'paste', {
+				dataTransfer: dataTransferMock,
+				preventDefault() {},
+				stopPropagation() {}
+			} );
+
+			expect( getModelData( model ) ).to.equal(
+				'<paragraph>' +
+					'<$text linkHref="ckeditor.com">f</$text>' +
+					'<$text linkHref="http://PASTED">PASTED[]</$text>' +
+					'<$text linkHref="ckeditor.com">oo</$text>' +
+				'</paragraph>'
+			);
+
+			expect( model.document.selection.isGravityOverridden ).to.be.false;
+		} );
+
+		it( 'should not override the gravity when pasting before another link (different URLs, they won\'t merge)', () => {
+			const dataTransferMock = createDataTransfer( { 'text/html': '<a href="http://PASTED">PASTED</a>' } );
+
+			setModelData( model, '<paragraph>[]<$text linkHref="ckeditor.com">foo</$text></paragraph>' );
+
+			expect( model.document.selection.isGravityOverridden ).to.be.false;
+
+			view.document.fire( 'paste', {
+				dataTransfer: dataTransferMock,
+				preventDefault() {},
+				stopPropagation() {}
+			} );
+
+			expect( getModelData( model ) ).to.equal(
+				'<paragraph>' +
+					'<$text linkHref="http://PASTED">PASTED[]</$text>' +
+					'<$text linkHref="ckeditor.com">foo</$text>' +
+				'</paragraph>'
+			);
+
+			expect( model.document.selection.isGravityOverridden ).to.be.false;
+		} );
+
 		it( 'should restore gravity on the next change:range', () => {
 			const dataTransferMock = createDataTransfer( { 'text/html': '<a href="ckeditor.com">PASTED</a>' } );
 

--- a/tests/manual/tickets/6053/1.html
+++ b/tests/manual/tickets/6053/1.html
@@ -1,0 +1,4 @@
+<div id="editor">
+	<p>Some <b>bold</b> text <a href="https://ckeditor.com">CKEditor</a> and <a href="https://cksource.com">CKSource</a>.</p>
+	<p>An "empty" paragraph to paste links:</p>
+</div>

--- a/tests/manual/tickets/6053/1.js
+++ b/tests/manual/tickets/6053/1.js
@@ -1,0 +1,19 @@
+/**
+ * @license Copyright (c) 2003-2020, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+/* globals console:false, document, window */
+
+import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor';
+import ArticlePluginSet from '@ckeditor/ckeditor5-core/tests/_utils/articlepluginset';
+
+ClassicEditor
+	.create( document.querySelector( '#editor' ), {
+		plugins: [ ArticlePluginSet ],
+		toolbar: [ 'undo', 'redo', 'link' ]
+	} )
+	.then( newEditor => {
+		window.editor = newEditor;
+	} )
+	.catch( err => console.error( err.stack ) );

--- a/tests/manual/tickets/6053/1.md
+++ b/tests/manual/tickets/6053/1.md
@@ -1,0 +1,18 @@
+# Issue [#6053](https://github.com/ckeditor/ckeditor5/issues/6053) manual test.
+
+## The gravity of the selection should be changed in some cases after the link was pasted
+
+1. Copy a part of a link in the content.
+2. Paste it a paragraph.
+
+**Expected**: The link should be pasted but you should be able to type unlinked text (the gravity overridden to the right) right away.
+
+1. Try copying and pasting links in different places:
+	1. In the middle of another link.
+	2. At the beginning/end of another link
+	3. Using links with different URLs.
+	4. When the selection gravity is already overridden at the boundary of an existing link (use arrow left and right keys).
+
+**Expected**: If a pasted link is not followed by another link, you should always be able to type unlinked text right away after pasting (the selection **should not** stick to the pasted link).
+
+**Tip**: If not sure, check the Model/Selection tab in the inspector and look for the `isGravityOverridden` property.


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: The gravity of the selection should be overridden if a link was pasted for better typing experience. Closes ckeditor/ckeditor5#6053.

