### PR TITLE
i/6053b: Link selection attributes should be cleared after inserting a link via `Model#insertContent()` for better UX

### DIFF
--- a/tests/linkediting.js
+++ b/tests/linkediting.js
@@ -94,7 +94,7 @@ describe( 'LinkEditing', () => {
 		} );
 
 		it( 'should be bound to th `linkHref` attribute (RTL)', async () => {
-			editor = await ClassicTestEditor.create( element, {
+			const editor = await ClassicTestEditor.create( element, {
 				plugins: [ Paragraph, LinkEditing, Enter ],
 				language: {
 					content: 'ar'

--- a/tests/linkediting.js
+++ b/tests/linkediting.js
@@ -93,35 +93,33 @@ describe( 'LinkEditing', () => {
 			expect( editor.model.document.selection.isGravityOverridden ).to.true;
 		} );
 
-		it( 'should be bound to th `linkHref` attribute (RTL)', () => {
-			return ClassicTestEditor
-				.create( element, {
-					plugins: [ Paragraph, LinkEditing, Enter ],
-					language: {
-						content: 'ar'
-					}
-				} )
-				.then( editor => {
-					model = editor.model;
-					view = editor.editing.view;
+		it( 'should be bound to th `linkHref` attribute (RTL)', async () => {
+			editor = await ClassicTestEditor.create( element, {
+				plugins: [ Paragraph, LinkEditing, Enter ],
+				language: {
+					content: 'ar'
+				}
+			} );
 
-					// Put selection before the link element.
-					setModelData( editor.model, '<paragraph>foo[]<$text linkHref="url">b</$text>ar</paragraph>' );
+			model = editor.model;
+			view = editor.editing.view;
 
-					// The selection's gravity is not overridden because selection landed here not because of `keydown`.
-					expect( editor.model.document.selection.isGravityOverridden ).to.false;
+			// Put selection before the link element.
+			setModelData( editor.model, '<paragraph>foo[]<$text linkHref="url">b</$text>ar</paragraph>' );
 
-					// So let's simulate the `keydown` event.
-					editor.editing.view.document.fire( 'keydown', {
-						keyCode: keyCodes.arrowleft,
-						preventDefault: () => {},
-						domTarget: document.body
-					} );
+			// The selection's gravity is not overridden because selection landed here not because of `keydown`.
+			expect( editor.model.document.selection.isGravityOverridden ).to.false;
 
-					expect( editor.model.document.selection.isGravityOverridden ).to.true;
+			// So let's simulate the `keydown` event.
+			editor.editing.view.document.fire( 'keydown', {
+				keyCode: keyCodes.arrowleft,
+				preventDefault: () => {},
+				domTarget: document.body
+			} );
 
-					return editor.destroy();
-				} );
+			expect( editor.model.document.selection.isGravityOverridden ).to.true;
+
+			await editor.destroy();
 		} );
 	} );
 
@@ -776,86 +774,80 @@ describe( 'LinkEditing', () => {
 				element.remove();
 			} );
 
-			it( 'should upcast attributes from initial data', () => {
-				return ClassicTestEditor
-					.create( element, {
-						initialData: '<p><a href="url" target="_blank" rel="noopener noreferrer" download="file">Foo</a>' +
-							'<a href="example.com" download="file">Bar</a></p>',
-						plugins: [ Paragraph, LinkEditing, Enter ],
-						link: {
-							decorators: {
-								isExternal: {
-									mode: 'manual',
-									label: 'Open in a new window',
-									attributes: {
-										target: '_blank',
-										rel: 'noopener noreferrer'
-									}
-								},
-								isDownloadable: {
-									mode: 'manual',
-									label: 'Downloadable',
-									attributes: {
-										download: 'file'
-									}
+			it( 'should upcast attributes from initial data', async () => {
+				editor = await ClassicTestEditor.create( element, {
+					initialData: '<p><a href="url" target="_blank" rel="noopener noreferrer" download="file">Foo</a>' +
+						'<a href="example.com" download="file">Bar</a></p>',
+					plugins: [ Paragraph, LinkEditing, Enter ],
+					link: {
+						decorators: {
+							isExternal: {
+								mode: 'manual',
+								label: 'Open in a new window',
+								attributes: {
+									target: '_blank',
+									rel: 'noopener noreferrer'
+								}
+							},
+							isDownloadable: {
+								mode: 'manual',
+								label: 'Downloadable',
+								attributes: {
+									download: 'file'
 								}
 							}
 						}
-					} )
-					.then( newEditor => {
-						editor = newEditor;
-						model = editor.model;
+					}
+				} );
 
-						expect( getModelData( model, { withoutSelection: true } ) ).to.equal(
-							'<paragraph>' +
-								'<$text linkHref="url" linkIsDownloadable="true" linkIsExternal="true">Foo</$text>' +
-								'<$text linkHref="example.com" linkIsDownloadable="true">Bar</$text>' +
-							'</paragraph>'
-						);
+				model = editor.model;
 
-						return editor.destroy();
-					} );
+				expect( getModelData( model, { withoutSelection: true } ) ).to.equal(
+					'<paragraph>' +
+						'<$text linkHref="url" linkIsDownloadable="true" linkIsExternal="true">Foo</$text>' +
+						'<$text linkHref="example.com" linkIsDownloadable="true">Bar</$text>' +
+					'</paragraph>'
+				);
+
+				await editor.destroy();
 			} );
 
-			it( 'should not upcast partial and incorrect attributes', () => {
-				return ClassicTestEditor
-					.create( element, {
-						initialData: '<p><a href="url" target="_blank" download="something">Foo</a>' +
-							'<a href="example.com" download="test">Bar</a></p>',
-						plugins: [ Paragraph, LinkEditing, Enter ],
-						link: {
-							decorators: {
-								isExternal: {
-									mode: 'manual',
-									label: 'Open in a new window',
-									attributes: {
-										target: '_blank',
-										rel: 'noopener noreferrer'
-									}
-								},
-								isDownloadable: {
-									mode: 'manual',
-									label: 'Downloadable',
-									attributes: {
-										download: 'file'
-									}
+			it( 'should not upcast partial and incorrect attributes', async () => {
+				editor = await ClassicTestEditor.create( element, {
+					initialData: '<p><a href="url" target="_blank" download="something">Foo</a>' +
+						'<a href="example.com" download="test">Bar</a></p>',
+					plugins: [ Paragraph, LinkEditing, Enter ],
+					link: {
+						decorators: {
+							isExternal: {
+								mode: 'manual',
+								label: 'Open in a new window',
+								attributes: {
+									target: '_blank',
+									rel: 'noopener noreferrer'
+								}
+							},
+							isDownloadable: {
+								mode: 'manual',
+								label: 'Downloadable',
+								attributes: {
+									download: 'file'
 								}
 							}
 						}
-					} )
-					.then( newEditor => {
-						editor = newEditor;
-						model = editor.model;
+					}
+				} );
 
-						expect( getModelData( model, { withoutSelection: true } ) ).to.equal(
-							'<paragraph>' +
-								'<$text linkHref="url">Foo</$text>' +
-								'<$text linkHref="example.com">Bar</$text>' +
-							'</paragraph>'
-						);
+				model = editor.model;
 
-						return editor.destroy();
-					} );
+				expect( getModelData( model, { withoutSelection: true } ) ).to.equal(
+					'<paragraph>' +
+						'<$text linkHref="url">Foo</$text>' +
+						'<$text linkHref="example.com">Bar</$text>' +
+					'</paragraph>'
+				);
+
+				await editor.destroy();
 			} );
 		} );
 	} );

--- a/tests/manual/tickets/6053/1.html
+++ b/tests/manual/tickets/6053/1.html
@@ -1,0 +1,4 @@
+<div id="editor">
+	<p>Some <b>bold</b> text <a href="https://ckeditor.com" download="download">CKEditor decorated</a> and <a href="https://cksource.com">CKSource</a>.</p>
+	<p>An "empty" paragraph to paste links:</p>
+</div>

--- a/tests/manual/tickets/6053/1.js
+++ b/tests/manual/tickets/6053/1.js
@@ -1,0 +1,30 @@
+/**
+ * @license Copyright (c) 2003-2020, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md or https://ckeditor.com/legal/ckeditor-oss-license
+ */
+
+/* globals console:false, document, window */
+
+import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor';
+import ArticlePluginSet from '@ckeditor/ckeditor5-core/tests/_utils/articlepluginset';
+
+ClassicEditor
+	.create( document.querySelector( '#editor' ), {
+		plugins: [ ArticlePluginSet ],
+		toolbar: [ 'undo', 'redo', 'link' ],
+		link: {
+			decorators: {
+				isDownloadable: {
+					mode: 'manual',
+					label: 'Downloadable',
+					attributes: {
+						download: 'download'
+					}
+				}
+			}
+		}
+	} )
+	.then( newEditor => {
+		window.editor = newEditor;
+	} )
+	.catch( err => console.error( err.stack ) );

--- a/tests/manual/tickets/6053/1.md
+++ b/tests/manual/tickets/6053/1.md
@@ -9,7 +9,7 @@
 
 1. Try copying and pasting links in different places:
 	1. In the middle of another link.
-	2. At the beginning/end of another link
+	2. At the beginning/end of another link.
 	3. Using links with different URLs.
 	4. When the selection gravity is overridden at the boundary of an existing link (use arrow left and right keys).
 

--- a/tests/manual/tickets/6053/1.md
+++ b/tests/manual/tickets/6053/1.md
@@ -1,0 +1,18 @@
+# Issue [#6053](https://github.com/ckeditor/ckeditor5/issues/6053) manual test.
+
+## The link selection attributes should cleared in certain situations after the link was pasted
+
+1. Copy a part of a link in the content.
+2. Paste it a paragraph.
+
+**Expected**: The link should be pasted but you should be able to type unlinked text right away.
+
+1. Try copying and pasting links in different places:
+	1. In the middle of another link.
+	2. At the beginning/end of another link
+	3. Using links with different URLs.
+	4. When the selection gravity is overridden at the boundary of an existing link (use arrow left and right keys).
+
+**Expected**: If a pasted link is not followed by another link, you should always be able to type unlinked text right away after pasting. There should be no selection attributes starting with "link".
+
+**Tip**: If not sure, check the Model/Selection tab in the inspector and look for selection attributes.


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Link selection attributes should be cleared after inserting a link via `Model#insertContent()` for better UX. Closes ckeditor/ckeditor5#6053.

---

### Additional information

A new approach to the problem ([the old one](https://github.com/ckeditor/ckeditor5-link/pull/260)) after a F2F talk with @Reinmar. Let's take a look at it and discuss it here.

FYI: I smuggled some async/await refactoring to the LinkEditing tests just like @jodator suggested in the old PR.